### PR TITLE
Adapt to cairo-lang v0.5.1 and Alpha testnet 3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -90,7 +90,7 @@ python-versions = "~=3.5"
 
 [[package]]
 name = "cairo-lang"
-version = "0.4.2"
+version = "0.5.1"
 description = "Compiler and runner for the Cairo language"
 category = "main"
 optional = false
@@ -103,7 +103,7 @@ ecdsa = "*"
 eth-hash = {version = "0.2.0", extras = ["pycryptodome"]}
 fastecdsa = "*"
 frozendict = "1.2"
-lark-parser = "0.8.5"
+lark-parser = "*"
 marshmallow = ">=3.2.1"
 marshmallow-dataclass = ">=7.1.0"
 marshmallow-enum = "*"
@@ -481,11 +481,16 @@ format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator 
 
 [[package]]
 name = "lark-parser"
-version = "0.8.5"
+version = "0.12.0"
 description = "a modern parsing library"
 category = "main"
 optional = false
 python-versions = "*"
+
+[package.extras]
+atomic_cache = ["atomicwrites"]
+nearley = ["js2py"]
+regex = ["regex"]
 
 [[package]]
 name = "lru-dict"
@@ -985,7 +990,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "88429df309bf650a1ce501c6e98a140fa8650716270b8ff53c50cf6bf0086f25"
+content-hash = "2ed90dd18d792765ea3e067d3b7cf24ebedac11fd71f03840c856f850542cb4e"
 
 [metadata.files]
 aiohttp = [
@@ -1055,7 +1060,7 @@ cachetools = [
     {file = "cachetools-4.2.4.tar.gz", hash = "sha256:89ea6f1b638d5a73a4f9226be57ac5e4f399d22770b92355f92dcb0f7f001693"},
 ]
 cairo-lang = [
-    {file = "cairo-lang-0.4.2.zip", hash = "sha256:7cdbfe1c23545dc2d0d7d5f97e4d3a02cce8a50881ca9c8796a6df44a945de12"},
+    {file = "cairo-lang-0.5.1.zip", hash = "sha256:b03b7e7479126c17c1537584bce52bdc776ad2a8618b00894f17f4dd26bc2a27"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -1183,8 +1188,8 @@ jsonschema = [
     {file = "jsonschema-3.2.0.tar.gz", hash = "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"},
 ]
 lark-parser = [
-    {file = "lark-parser-0.8.5.tar.gz", hash = "sha256:e3ee17708e310de3a832a9beb448aa60ab6812f1bb283f72d473584c7566cc74"},
-    {file = "lark_parser-0.8.5-py2.py3-none-any.whl", hash = "sha256:157879e04628e8e2bd57b72f3ba5642b3919137d5f7058612e95a38fb8761fa7"},
+    {file = "lark-parser-0.12.0.tar.gz", hash = "sha256:15967db1f1214013dca65b1180745047b9be457d73da224fcda3d9dd4e96a138"},
+    {file = "lark_parser-0.12.0-py2.py3-none-any.whl", hash = "sha256:0eaf30cb5ba787fe404d73a7d6e61df97b21d5a63ac26c5008c78a494373c675"},
 ]
 lru-dict = [
     {file = "lru-dict-1.1.7.tar.gz", hash = "sha256:45b81f67d75341d4433abade799a47e9c42a9e22a118531dcb5e549864032d7c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = ["starknet", "cairo", "testnet", "local", "server"]
 [tool.poetry.dependencies]
 python = "^3.7"
 Flask = {extras = ["async"], version = "^2.0.2"}
-cairo-lang = "^0.4.2"
+cairo-lang = "0.5.1"
 
 [tool.poetry.dev-dependencies]
 

--- a/scripts/hardhat.config.ts
+++ b/scripts/hardhat.config.ts
@@ -9,7 +9,7 @@ import "@shardlabs/starknet-hardhat-plugin";
 module.exports = {
   solidity: "0.8.4",
   cairo: {
-    version: "0.4.2"
+    version: "0.5.1"
   },
   networks: {
     starknetLocalhost: {

--- a/scripts/setup-example.sh
+++ b/scripts/setup-example.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+echo "Cloning branch 'devnet'"
 git clone -b devnet --single-branch git@github.com:Shard-Labs/starknet-hardhat-example.git
 cd starknet-hardhat-example
 npm ci

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -10,6 +10,7 @@ from .util import TxStatus, parse_args
 
 app = Flask(__name__)
 address2contract = {}
+address2types = {}
 transactions = []
 
 class StarknetWrapper:
@@ -32,8 +33,9 @@ def is_alive():
 async def deploy(contract_definition: ContractDefinition):
     starknet = await starknet_wrapper.get_starknet()
     contract = await starknet.deploy(contract_def=contract_definition)
-    address2contract[contract.contract_address] = contract
-    return contract.contract_address, {}
+    hex_address = hex(contract.contract_address)
+    address2contract[hex_address] = contract
+    return hex_address, {}
 
 def attempt_hex(x):
     try:
@@ -42,7 +44,26 @@ def attempt_hex(x):
         pass
     return x
 
-def adapt_calldata(calldata, expected_inputs):
+def generate_complex(calldata, calldata_i, input_type, types):
+    if input_type == "felt":
+        return calldata[calldata_i], calldata_i + 1
+
+    arr = []
+    if input_type[0] == "(" and input_type[-1] == ")":
+        members = input_type[1:-1].split(", ")
+    else:
+        if input_type not in types:
+            raise ValueError(f"Unsupported type: {input_type}")
+        struct = types[input_type]
+        members = [x["type"] for x in struct["members"]]
+
+    for member in members:
+        generated_complex, calldata_i = generate_complex(calldata, calldata_i, member, types)
+        arr.append(generated_complex)
+
+    return tuple(arr), calldata_i
+
+def adapt_calldata(calldata, expected_inputs, types):
     last_name = None
     last_value = None
     calldata_i = 0
@@ -70,19 +91,32 @@ def adapt_calldata(calldata, expected_inputs):
         elif input_type == "felt":
             adapted_calldata.append(input_value)
             calldata_i += 1
-        else:
-            parse_input_type() # TODO
-            # probably never reached if `getattr(contract, method_name)` is called before
-            abort(Response(f"Input type not supported:{input_type}.", 400))
+
+        else: # struct
+            try:
+                generated_complex, calldata_i = generate_complex(calldata, calldata_i, input_type, types)
+            except ValueError as e:
+                abort(Response(str(e), 400))
+            adapted_calldata.append(generated_complex)
 
         last_name = input_name
         last_value = input_value
 
     return adapted_calldata
 
+def adapt_output(received, ret):
+    if isinstance(received, list):
+        ret.append(hex(len(received)))
+    try:
+        for el in received:
+            adapt_output(el, ret)
+    except TypeError:
+        ret.append(hex(received))
+
 async def call_or_invoke(choice, contract_address: str, entry_point_selector: int, calldata: list):
+    contract_address = hex(contract_address)
     if (contract_address not in address2contract):
-        abort(Response(f"No contract at the provided address ({hex(contract_address)}).", 400))
+        abort(Response(f"No contract at the provided address ({contract_address}).", 400))
 
     contract: StarknetContract = address2contract[contract_address]
     for method_name in contract._abi_function_mapping:
@@ -98,31 +132,58 @@ async def call_or_invoke(choice, contract_address: str, entry_point_selector: in
     else:
         abort(Response(f"Illegal method selector: {entry_point_selector}.", 400))
 
-    adapted_calldata = adapt_calldata(calldata, function_abi["inputs"])
+    types = address2types[contract_address]
+    adapted_calldata = adapt_calldata(calldata, function_abi["inputs"], types)
 
     prepared = method(*adapted_calldata)
     called = getattr(prepared, choice)
     executed = await called()
 
-    return { "result": [attempt_hex(r) for r in executed.result] }
+    adapted_output = []
+    adapt_output(executed.result, adapted_output)
+
+    return { "result": adapted_output }
 
 def is_transaction_hash_legal(transaction_hash: int) -> bool:
     return 0 <= transaction_hash < len(transactions)
+
+def store_types(contract_address: str, abi):
+    structs = [x for x in abi if x["type"] == "struct"]
+    type_dict = { struct["name"]: struct for struct in structs }
+    address2types[contract_address] = type_dict
+
+def store_transaction(contract_address: str, tx_type: str) -> str:
+    new_id = len(transactions)
+    hex_new_id = hex(new_id)
+    transaction = {
+        "block_id": new_id,
+        "block_number": new_id,
+        "status": TxStatus.PENDING.name,
+        "transaction": {
+            "contract_address": contract_address,
+            "type": tx_type
+        },
+        "transaction_hash": hex_new_id,
+        "transaction_index": 0 # always the first (and only) tx in the block
+    }
+    transactions.append(transaction)
+    return hex_new_id
 
 @app.route("/gateway/add_transaction", methods=["POST"])
 async def add_transaction():
     raw_data = request.get_data()
     transaction = Transaction.loads(raw_data)
+    # TODO transaction.calculate_hash()
 
     tx_type = transaction.tx_type.name
     result_dict = {}
     if tx_type == "DEPLOY":
-        # TODO store all types from contract_definition and their sizes
         contract_address, result_dict = await deploy(
             transaction.contract_definition
         )
+        store_types(contract_address, transaction.contract_definition.abi)
     elif tx_type == "INVOKE_FUNCTION":
-        contract_address = transaction.contract_address
+        contract_address = hex(transaction.contract_address)
         result_dict = await call_or_invoke("invoke",
             contract_address=transaction.contract_address,
             entry_point_selector=transaction.entry_point_selector,
@@ -131,26 +192,12 @@ async def add_transaction():
     else:
         abort(Response(f"Invalid tx_type: {tx_type}.", 400))
 
-    hex_address = hex(contract_address)
-    new_id = len(transactions)
-    hex_new_id = hex(new_id)
-    transaction = {
-        "block_id": new_id,
-        "block_number": new_id,
-        "status": TxStatus.PENDING.name,
-        "transaction": {
-            "contract_address": hex_address,
-            "type": tx_type
-        },
-        "transaction_hash": hex_new_id,
-        "transaction_index": 0 # always the first (and only) tx in the block
-    }
-    transactions.append(transaction)
+    transaction_hash = store_transaction(contract_address, tx_type)
 
     return jsonify({
         "code": StarkErrorCode.TRANSACTION_RECEIVED.name,
-        "transaction_hash": hex_new_id,
-        "address": hex_address,
+        "transaction_hash": transaction_hash,
+        "address": contract_address,
         **result_dict
     })
 

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -71,6 +71,7 @@ def adapt_calldata(calldata, expected_inputs):
             adapted_calldata.append(input_value)
             calldata_i += 1
         else:
+            parse_input_type() # TODO
             # probably never reached if `getattr(contract, method_name)` is called before
             abort(Response(f"Input type not supported:{input_type}.", 400))
 
@@ -116,6 +117,7 @@ async def add_transaction():
     tx_type = transaction.tx_type.name
     result_dict = {}
     if tx_type == "DEPLOY":
+        # TODO store all types from contract_definition and their sizes
         contract_address, result_dict = await deploy(
             transaction.contract_definition
         )


### PR DESCRIPTION
- Dependencies are updated (lark-parser and cairo-lang).
- StarkNet functions now accept structs and tuples as parameters (includes nested structs/tuples).
- Since returned objects can also be complex (i.e. nested), proper adaptation is done on output.
- The nested structures are resolve using recursion.
- Transactions are no longer identified using ID but transaction hash.
- Contract addresses are internally stored as hex strings (used to be int).