### PR TITLE
Fix "'type' object is not subscriptable" error for python versions < 3.9

### DIFF
--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -121,7 +121,7 @@ async def call_contract():
 
     return jsonify(result_dict)
 
-def check_block_hash(request_args: MultiDict[str, str]):
+def check_block_hash(request_args: MultiDict):
     block_hash = request_args.get("blockHash", type=custom_int)
     if block_hash is not None:
         print("Specifying a block by its hash is not supported. All interaction is done with the latest block.")


### PR DESCRIPTION
As mentioned in https://github.com/Shard-Labs/starknet-devnet/issues/15 version 0.1.8 doesn't work on python 3.7. I've checked and it works only on python >= 3.9. 
This is because `MultiDict` inherits from `dict` and 3.9 makes dict generic: https://docs.python.org/3/whatsnew/3.9.html#type-hinting-generics-in-standard-collections.