### PR TITLE
Support linting; Add plugin-venv test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,12 @@ jobs:
           name: Test CLI with authentication
           command: ./scripts/test_cli_auth.sh
       - run:
-          name: Test plugin
-          command: ./scripts/test_plugin.sh
+          name: Test plugin - dockerized
+          command: HARDHAT_CONFIG=../scripts/hardhat.config.dockerized.ts ./scripts/test_plugin.sh
+          no_output_timeout: 1m
+      - run:
+          name: Test plugin - venv
+          command: HARDHAT_CONFIG=../scripts/hardhat.config.venv.ts ./scripts/test_plugin.sh
           no_output_timeout: 1m
   package_build_and_publish:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,12 +34,18 @@ jobs:
           command: ./scripts/test_cli_auth.sh
       - run:
           name: Test plugin - dockerized
-          command: HARDHAT_CONFIG_FILE=../scripts/hardhat.config.dockerized.ts ./scripts/test_plugin.sh
+          command: ./scripts/test_plugin.sh
           no_output_timeout: 1m
+          environment:
+            HARDHAT_CONFIG_FILE: ../scripts/hardhat.config.dockerized.ts
+            TEST_FILE: test/quick-test.ts
       - run:
           name: Test plugin - venv
-          command: HARDHAT_CONFIG_FILE=../scripts/hardhat.config.venv.ts ./scripts/test_plugin.sh
+          command: ./scripts/test_plugin.sh
           no_output_timeout: 1m
+          environment:
+            HARDHAT_CONFIG_FILE: ../scripts/hardhat.config.venv.ts
+            TEST_FILE: test/sample-test.ts
   package_build_and_publish:
     docker:
       - image: cimg/python:3.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,11 +34,11 @@ jobs:
           command: ./scripts/test_cli_auth.sh
       - run:
           name: Test plugin - dockerized
-          command: HARDHAT_CONFIG=../scripts/hardhat.config.dockerized.ts ./scripts/test_plugin.sh
+          command: HARDHAT_CONFIG_FILE=../scripts/hardhat.config.dockerized.ts ./scripts/test_plugin.sh
           no_output_timeout: 1m
       - run:
           name: Test plugin - venv
-          command: HARDHAT_CONFIG=../scripts/hardhat.config.venv.ts ./scripts/test_plugin.sh
+          command: HARDHAT_CONFIG_FILE=../scripts/hardhat.config.venv.ts ./scripts/test_plugin.sh
           no_output_timeout: 1m
   package_build_and_publish:
     docker:

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[FORMAT]
+max-line-length=150

--- a/poetry.lock
+++ b/poetry.lock
@@ -46,6 +46,20 @@ typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
 
 [[package]]
+name = "astroid"
+version = "2.9.0"
+description = "An abstract syntax tree for Python with inference support."
+category = "dev"
+optional = false
+python-versions = "~=3.6"
+
+[package.dependencies]
+lazy-object-proxy = ">=1.4.0"
+typed-ast = {version = ">=1.4.0,<2.0", markers = "implementation_name == \"cpython\" and python_version < \"3.8\""}
+typing-extensions = {version = ">=3.10", markers = "python_version < \"3.10\""}
+wrapt = ">=1.11,<1.14"
+
+[[package]]
 name = "async-timeout"
 version = "4.0.1"
 description = "Timeout context manager for asyncio programs"
@@ -477,6 +491,20 @@ multiaddr = ">=0.0.7"
 requests = ">=2.11"
 
 [[package]]
+name = "isort"
+version = "5.10.1"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1,<4.0"
+
+[package.extras]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+plugins = ["setuptools"]
+
+[[package]]
 name = "itsdangerous"
 version = "2.0.1"
 description = "Safely pass data to untrusted environments and back."
@@ -528,6 +556,14 @@ python-versions = "*"
 atomic_cache = ["atomicwrites"]
 nearley = ["js2py"]
 regex = ["regex"]
+
+[[package]]
+name = "lazy-object-proxy"
+version = "1.7.1"
+description = "A fast and thorough lazy object proxy."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "lru-dict"
@@ -605,6 +641,14 @@ marshmallow = ">=3.0.0,<4.0.0"
 dev = ["pytest", "mock", "flake8 (==3.9.2)", "flake8-bugbear (==21.4.3)", "pre-commit (>=2.7,<3.0)", "tox"]
 lint = ["flake8 (==3.9.2)", "flake8-bugbear (==21.4.3)", "pre-commit (>=2.7,<3.0)"]
 tests = ["pytest", "mock"]
+
+[[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "mpmath"
@@ -698,6 +742,18 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 graphviz = ["graphviz"]
 
 [[package]]
+name = "platformdirs"
+version = "2.4.0"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+
+[[package]]
 name = "pluggy"
 version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
@@ -746,6 +802,23 @@ description = "Cryptographic library for Python"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pylint"
+version = "2.12.2"
+description = "python code static checker"
+category = "dev"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+astroid = ">=2.9.0,<2.10"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+isort = ">=4.2.5,<6"
+mccabe = ">=0.6,<0.7"
+platformdirs = ">=2.2.0"
+toml = ">=0.9.2"
+typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
 
 [[package]]
 name = "pyparsing"
@@ -898,6 +971,14 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "typed-ast"
+version = "1.5.1"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "typeguard"
 version = "2.13.0"
 description = "Run-time type checker for Python"
@@ -1000,6 +1081,14 @@ python-versions = ">=3.6"
 watchdog = ["watchdog"]
 
 [[package]]
+name = "wrapt"
+version = "1.13.3"
+description = "Module for decorators, wrappers and monkey patching."
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
 name = "yarl"
 version = "1.7.2"
 description = "Yet another URL library"
@@ -1027,7 +1116,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "6c61ecdadb44e5150281d9fbc4e3cc8ec9c76c34ae71f0bd5fc7a717df98bedd"
+content-hash = "87ebb4f0be23da31c78631efdaa5906590dc5212f70cab3468a31210fbd6f34c"
 
 [metadata.files]
 aiohttp = [
@@ -1111,6 +1200,10 @@ aiosignal = [
 asgiref = [
     {file = "asgiref-3.4.1-py3-none-any.whl", hash = "sha256:ffc141aa908e6f175673e7b1b3b7af4fdb0ecb738fc5c8b88f69f055c2415214"},
     {file = "asgiref-3.4.1.tar.gz", hash = "sha256:4ef1ab46b484e3c706329cedeff284a5d40824200638503f5768edb6de7d58e9"},
+]
+astroid = [
+    {file = "astroid-2.9.0-py3-none-any.whl", hash = "sha256:776ca0b748b4ad69c00bfe0fff38fa2d21c338e12c84aa9715ee0d473c422778"},
+    {file = "astroid-2.9.0.tar.gz", hash = "sha256:5939cf55de24b92bda00345d4d0659d01b3c7dafb5055165c330bc7c568ba273"},
 ]
 async-timeout = [
     {file = "async-timeout-4.0.1.tar.gz", hash = "sha256:b930cb161a39042f9222f6efb7301399c87eeab394727ec5437924a36d6eef51"},
@@ -1305,6 +1398,10 @@ ipfshttpclient = [
     {file = "ipfshttpclient-0.6.1-py3-none-any.whl", hash = "sha256:9abc46e43e573e0e25544689bc2f264b3183de1dfcf9186d349213c164ce8216"},
     {file = "ipfshttpclient-0.6.1.tar.gz", hash = "sha256:fb2b12b249dd45c4110b946a16c03ec1eeba6789791bd425e678d93c3f631098"},
 ]
+isort = [
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
+]
 itsdangerous = [
     {file = "itsdangerous-2.0.1-py3-none-any.whl", hash = "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c"},
     {file = "itsdangerous-2.0.1.tar.gz", hash = "sha256:9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0"},
@@ -1320,6 +1417,45 @@ jsonschema = [
 lark-parser = [
     {file = "lark-parser-0.12.0.tar.gz", hash = "sha256:15967db1f1214013dca65b1180745047b9be457d73da224fcda3d9dd4e96a138"},
     {file = "lark_parser-0.12.0-py2.py3-none-any.whl", hash = "sha256:0eaf30cb5ba787fe404d73a7d6e61df97b21d5a63ac26c5008c78a494373c675"},
+]
+lazy-object-proxy = [
+    {file = "lazy-object-proxy-1.7.1.tar.gz", hash = "sha256:d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb8c5fd1684d60a9902c60ebe276da1f2281a318ca16c1d0a96db28f62e9166b"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a57d51ed2997e97f3b8e3500c984db50a554bb5db56c50b5dab1b41339b37e36"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd45683c3caddf83abbb1249b653a266e7069a09f486daa8863fb0e7496a9fdb"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:8561da8b3dd22d696244d6d0d5330618c993a215070f473b699e00cf1f3f6443"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fccdf7c2c5821a8cbd0a9440a456f5050492f2270bd54e94360cac663398739b"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-win32.whl", hash = "sha256:898322f8d078f2654d275124a8dd19b079080ae977033b713f677afcfc88e2b9"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:85b232e791f2229a4f55840ed54706110c80c0a210d076eee093f2b2e33e1bfd"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:46ff647e76f106bb444b4533bb4153c7370cdf52efc62ccfc1a28bdb3cc95442"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:12f3bb77efe1367b2515f8cb4790a11cffae889148ad33adad07b9b55e0ab22c"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c19814163728941bb871240d45c4c30d33b8a2e85972c44d4e63dd7107faba44"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:e40f2013d96d30217a51eeb1db28c9ac41e9d0ee915ef9d00da639c5b63f01a1"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:2052837718516a94940867e16b1bb10edb069ab475c3ad84fd1e1a6dd2c0fcfc"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-win32.whl", hash = "sha256:6a24357267aa976abab660b1d47a34aaf07259a0c3859a34e536f1ee6e76b5bb"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-win_amd64.whl", hash = "sha256:6aff3fe5de0831867092e017cf67e2750c6a1c7d88d84d2481bd84a2e019ec35"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6a6e94c7b02641d1311228a102607ecd576f70734dc3d5e22610111aeacba8a0"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4ce15276a1a14549d7e81c243b887293904ad2d94ad767f42df91e75fd7b5b6"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e368b7f7eac182a59ff1f81d5f3802161932a41dc1b1cc45c1f757dc876b5d2c"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:6ecbb350991d6434e1388bee761ece3260e5228952b1f0c46ffc800eb313ff42"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:553b0f0d8dbf21890dd66edd771f9b1b5f51bd912fa5f26de4449bfc5af5e029"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-win32.whl", hash = "sha256:c7a683c37a8a24f6428c28c561c80d5f4fd316ddcf0c7cab999b15ab3f5c5c69"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-win_amd64.whl", hash = "sha256:df2631f9d67259dc9620d831384ed7732a198eb434eadf69aea95ad18c587a28"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:07fa44286cda977bd4803b656ffc1c9b7e3bc7dff7d34263446aec8f8c96f88a"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4dca6244e4121c74cc20542c2ca39e5c4a5027c81d112bfb893cf0790f96f57e"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:91ba172fc5b03978764d1df5144b4ba4ab13290d7bab7a50f12d8117f8630c38"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:043651b6cb706eee4f91854da4a089816a6606c1428fd391573ef8cb642ae4f7"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b9e89b87c707dd769c4ea91f7a31538888aad05c116a59820f28d59b3ebfe25a"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-win32.whl", hash = "sha256:9d166602b525bf54ac994cf833c385bfcc341b364e3ee71e3bf5a1336e677b55"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:8f3953eb575b45480db6568306893f0bd9d8dfeeebd46812aa09ca9579595148"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:dd7ed7429dbb6c494aa9bc4e09d94b778a3579be699f9d67da7e6804c422d3de"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70ed0c2b380eb6248abdef3cd425fc52f0abd92d2b07ce26359fcbc399f636ad"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7096a5e0c1115ec82641afbdd70451a144558ea5cf564a896294e346eb611be1"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f769457a639403073968d118bc70110e7dce294688009f5c24ab78800ae56dc8"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:39b0e26725c5023757fc1ab2a89ef9d7ab23b84f9251e28f9cc114d5b59c1b09"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-win32.whl", hash = "sha256:2130db8ed69a48a3440103d4a520b89d8a9405f1b06e2cc81640509e8bf6548f"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:677ea950bef409b47e51e733283544ac3d660b709cfce7b187f5ace137960d61"},
+    {file = "lazy_object_proxy-1.7.1-pp37.pp38-none-any.whl", hash = "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84"},
 ]
 lru-dict = [
     {file = "lru-dict-1.1.7.tar.gz", hash = "sha256:45b81f67d75341d4433abade799a47e9c42a9e22a118531dcb5e549864032d7c"},
@@ -1395,6 +1531,10 @@ marshmallow-enum = [
 marshmallow-oneofschema = [
     {file = "marshmallow-oneofschema-3.0.1.tar.gz", hash = "sha256:62cd2099b29188c92493c2940ee79d1bf2f2619a71721664e5a98ec2faa58237"},
     {file = "marshmallow_oneofschema-3.0.1-py2.py3-none-any.whl", hash = "sha256:bd29410a9f2f7457a2b428286e2a80ef76b8ddc3701527dc1f935a88914b02f2"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 mpmath = [
     {file = "mpmath-1.2.1-py3-none-any.whl", hash = "sha256:604bc21bd22d2322a177c73bdb573994ef76e62edd595d17e00aff24b0667e5c"},
@@ -1528,6 +1668,10 @@ pipdeptree = [
     {file = "pipdeptree-2.2.0-py3-none-any.whl", hash = "sha256:95fb603e46343651342583c337a0ee68d3ccade7a81f5cf6b2fbd8151b79ed80"},
     {file = "pipdeptree-2.2.0.tar.gz", hash = "sha256:21a89e77d6eae635685e8af5ecd56561f092f8216bb290e7ae5362885d611f60"},
 ]
+platformdirs = [
+    {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
+    {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
+]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
@@ -1597,6 +1741,10 @@ pycryptodome = [
     {file = "pycryptodome-3.11.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:7ff701fc283412e651eaab4319b3cd4eaa0827e94569cd37ee9075d5c05fe655"},
     {file = "pycryptodome-3.11.0-pp36-pypy36_pp73-win32.whl", hash = "sha256:2a4bcc8a9977fee0979079cd33a9e9f0d3ddba5660d35ffe874cf84f1dd399d2"},
     {file = "pycryptodome-3.11.0.tar.gz", hash = "sha256:428096bbf7a77e207f418dfd4d7c284df8ade81d2dc80f010e92753a3e406ad0"},
+]
+pylint = [
+    {file = "pylint-2.12.2-py3-none-any.whl", hash = "sha256:daabda3f7ed9d1c60f52d563b1b854632fd90035bcf01443e234d3dc794e3b74"},
+    {file = "pylint-2.12.2.tar.gz", hash = "sha256:9d945a73640e1fec07ee34b42f5669b770c759acd536ec7b16d7e4b87a9c9ff9"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -1688,6 +1836,27 @@ toolz = [
     {file = "toolz-0.11.2-py3-none-any.whl", hash = "sha256:a5700ce83414c64514d82d60bcda8aabfde092d1c1a8663f9200c07fdcc6da8f"},
     {file = "toolz-0.11.2.tar.gz", hash = "sha256:6b312d5e15138552f1bda8a4e66c30e236c831b612b2bf0005f8a1df10a4bc33"},
 ]
+typed-ast = [
+    {file = "typed_ast-1.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5d8314c92414ce7481eee7ad42b353943679cf6f30237b5ecbf7d835519e1212"},
+    {file = "typed_ast-1.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b53ae5de5500529c76225d18eeb060efbcec90ad5e030713fe8dab0fb4531631"},
+    {file = "typed_ast-1.5.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:24058827d8f5d633f97223f5148a7d22628099a3d2efe06654ce872f46f07cdb"},
+    {file = "typed_ast-1.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:a6d495c1ef572519a7bac9534dbf6d94c40e5b6a608ef41136133377bba4aa08"},
+    {file = "typed_ast-1.5.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:de4ecae89c7d8b56169473e08f6bfd2df7f95015591f43126e4ea7865928677e"},
+    {file = "typed_ast-1.5.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:256115a5bc7ea9e665c6314ed6671ee2c08ca380f9d5f130bd4d2c1f5848d695"},
+    {file = "typed_ast-1.5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:7c42707ab981b6cf4b73490c16e9d17fcd5227039720ca14abe415d39a173a30"},
+    {file = "typed_ast-1.5.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:71dcda943a471d826ea930dd449ac7e76db7be778fcd722deb63642bab32ea3f"},
+    {file = "typed_ast-1.5.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4f30a2bcd8e68adbb791ce1567fdb897357506f7ea6716f6bbdd3053ac4d9471"},
+    {file = "typed_ast-1.5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:ca9e8300d8ba0b66d140820cf463438c8e7b4cdc6fd710c059bfcfb1531d03fb"},
+    {file = "typed_ast-1.5.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9caaf2b440efb39ecbc45e2fabde809cbe56272719131a6318fd9bf08b58e2cb"},
+    {file = "typed_ast-1.5.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c9bcad65d66d594bffab8575f39420fe0ee96f66e23c4d927ebb4e24354ec1af"},
+    {file = "typed_ast-1.5.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:591bc04e507595887160ed7aa8d6785867fb86c5793911be79ccede61ae96f4d"},
+    {file = "typed_ast-1.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:a80d84f535642420dd17e16ae25bb46c7f4c16ee231105e7f3eb43976a89670a"},
+    {file = "typed_ast-1.5.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:38cf5c642fa808300bae1281460d4f9b7617cf864d4e383054a5ef336e344d32"},
+    {file = "typed_ast-1.5.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5b6ab14c56bc9c7e3c30228a0a0b54b915b1579613f6e463ba6f4eb1382e7fd4"},
+    {file = "typed_ast-1.5.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a2b8d7007f6280e36fa42652df47087ac7b0a7d7f09f9468f07792ba646aac2d"},
+    {file = "typed_ast-1.5.1-cp39-cp39-win_amd64.whl", hash = "sha256:b6d17f37f6edd879141e64a5db17b67488cfeffeedad8c5cec0392305e9bc775"},
+    {file = "typed_ast-1.5.1.tar.gz", hash = "sha256:484137cab8ecf47e137260daa20bafbba5f4e3ec7fda1c1e69ab299b75fa81c5"},
+]
 typeguard = [
     {file = "typeguard-2.13.0-py3-none-any.whl", hash = "sha256:0bc44d1ff865b522eda969627868b0e001c8329296ce50aededbea03febc79ee"},
     {file = "typeguard-2.13.0.tar.gz", hash = "sha256:04e38f92eb59410c9375d3be23df65e0a7643f2e8bcbd421423d808d2f9e99df"},
@@ -1740,6 +1909,59 @@ websockets = [
 werkzeug = [
     {file = "Werkzeug-2.0.2-py3-none-any.whl", hash = "sha256:63d3dc1cf60e7b7e35e97fa9861f7397283b75d765afcaefd993d6046899de8f"},
     {file = "Werkzeug-2.0.2.tar.gz", hash = "sha256:aa2bb6fc8dee8d6c504c0ac1e7f5f7dc5810a9903e793b6f715a9f015bdadb9a"},
+]
+wrapt = [
+    {file = "wrapt-1.13.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:e05e60ff3b2b0342153be4d1b597bbcfd8330890056b9619f4ad6b8d5c96a81a"},
+    {file = "wrapt-1.13.3-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:85148f4225287b6a0665eef08a178c15097366d46b210574a658c1ff5b377489"},
+    {file = "wrapt-1.13.3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:2dded5496e8f1592ec27079b28b6ad2a1ef0b9296d270f77b8e4a3a796cf6909"},
+    {file = "wrapt-1.13.3-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:e94b7d9deaa4cc7bac9198a58a7240aaf87fe56c6277ee25fa5b3aa1edebd229"},
+    {file = "wrapt-1.13.3-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:498e6217523111d07cd67e87a791f5e9ee769f9241fcf8a379696e25806965af"},
+    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:ec7e20258ecc5174029a0f391e1b948bf2906cd64c198a9b8b281b811cbc04de"},
+    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:87883690cae293541e08ba2da22cacaae0a092e0ed56bbba8d018cc486fbafbb"},
+    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:f99c0489258086308aad4ae57da9e8ecf9e1f3f30fa35d5e170b4d4896554d80"},
+    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:6a03d9917aee887690aa3f1747ce634e610f6db6f6b332b35c2dd89412912bca"},
+    {file = "wrapt-1.13.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:936503cb0a6ed28dbfa87e8fcd0a56458822144e9d11a49ccee6d9a8adb2ac44"},
+    {file = "wrapt-1.13.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f9c51d9af9abb899bd34ace878fbec8bf357b3194a10c4e8e0a25512826ef056"},
+    {file = "wrapt-1.13.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:220a869982ea9023e163ba915077816ca439489de6d2c09089b219f4e11b6785"},
+    {file = "wrapt-1.13.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:0877fe981fd76b183711d767500e6b3111378ed2043c145e21816ee589d91096"},
+    {file = "wrapt-1.13.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:43e69ffe47e3609a6aec0fe723001c60c65305784d964f5007d5b4fb1bc6bf33"},
+    {file = "wrapt-1.13.3-cp310-cp310-win32.whl", hash = "sha256:78dea98c81915bbf510eb6a3c9c24915e4660302937b9ae05a0947164248020f"},
+    {file = "wrapt-1.13.3-cp310-cp310-win_amd64.whl", hash = "sha256:ea3e746e29d4000cd98d572f3ee2a6050a4f784bb536f4ac1f035987fc1ed83e"},
+    {file = "wrapt-1.13.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:8c73c1a2ec7c98d7eaded149f6d225a692caa1bd7b2401a14125446e9e90410d"},
+    {file = "wrapt-1.13.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:086218a72ec7d986a3eddb7707c8c4526d677c7b35e355875a0fe2918b059179"},
+    {file = "wrapt-1.13.3-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:e92d0d4fa68ea0c02d39f1e2f9cb5bc4b4a71e8c442207433d8db47ee79d7aa3"},
+    {file = "wrapt-1.13.3-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:d4a5f6146cfa5c7ba0134249665acd322a70d1ea61732723c7d3e8cc0fa80755"},
+    {file = "wrapt-1.13.3-cp35-cp35m-win32.whl", hash = "sha256:8aab36778fa9bba1a8f06a4919556f9f8c7b33102bd71b3ab307bb3fecb21851"},
+    {file = "wrapt-1.13.3-cp35-cp35m-win_amd64.whl", hash = "sha256:944b180f61f5e36c0634d3202ba8509b986b5fbaf57db3e94df11abee244ba13"},
+    {file = "wrapt-1.13.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:2ebdde19cd3c8cdf8df3fc165bc7827334bc4e353465048b36f7deeae8ee0918"},
+    {file = "wrapt-1.13.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:610f5f83dd1e0ad40254c306f4764fcdc846641f120c3cf424ff57a19d5f7ade"},
+    {file = "wrapt-1.13.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5601f44a0f38fed36cc07db004f0eedeaadbdcec90e4e90509480e7e6060a5bc"},
+    {file = "wrapt-1.13.3-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:e6906d6f48437dfd80464f7d7af1740eadc572b9f7a4301e7dd3d65db285cacf"},
+    {file = "wrapt-1.13.3-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:766b32c762e07e26f50d8a3468e3b4228b3736c805018e4b0ec8cc01ecd88125"},
+    {file = "wrapt-1.13.3-cp36-cp36m-win32.whl", hash = "sha256:5f223101f21cfd41deec8ce3889dc59f88a59b409db028c469c9b20cfeefbe36"},
+    {file = "wrapt-1.13.3-cp36-cp36m-win_amd64.whl", hash = "sha256:f122ccd12fdc69628786d0c947bdd9cb2733be8f800d88b5a37c57f1f1d73c10"},
+    {file = "wrapt-1.13.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:46f7f3af321a573fc0c3586612db4decb7eb37172af1bc6173d81f5b66c2e068"},
+    {file = "wrapt-1.13.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:778fd096ee96890c10ce96187c76b3e99b2da44e08c9e24d5652f356873f6709"},
+    {file = "wrapt-1.13.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0cb23d36ed03bf46b894cfec777eec754146d68429c30431c99ef28482b5c1df"},
+    {file = "wrapt-1.13.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:96b81ae75591a795d8c90edc0bfaab44d3d41ffc1aae4d994c5aa21d9b8e19a2"},
+    {file = "wrapt-1.13.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:7dd215e4e8514004c8d810a73e342c536547038fb130205ec4bba9f5de35d45b"},
+    {file = "wrapt-1.13.3-cp37-cp37m-win32.whl", hash = "sha256:47f0a183743e7f71f29e4e21574ad3fa95676136f45b91afcf83f6a050914829"},
+    {file = "wrapt-1.13.3-cp37-cp37m-win_amd64.whl", hash = "sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea"},
+    {file = "wrapt-1.13.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b73d4b78807bd299b38e4598b8e7bd34ed55d480160d2e7fdaabd9931afa65f9"},
+    {file = "wrapt-1.13.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ec9465dd69d5657b5d2fa6133b3e1e989ae27d29471a672416fd729b429eb554"},
+    {file = "wrapt-1.13.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:dd91006848eb55af2159375134d724032a2d1d13bcc6f81cd8d3ed9f2b8e846c"},
+    {file = "wrapt-1.13.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ae9de71eb60940e58207f8e71fe113c639da42adb02fb2bcbcaccc1ccecd092b"},
+    {file = "wrapt-1.13.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:51799ca950cfee9396a87f4a1240622ac38973b6df5ef7a41e7f0b98797099ce"},
+    {file = "wrapt-1.13.3-cp38-cp38-win32.whl", hash = "sha256:4b9c458732450ec42578b5642ac53e312092acf8c0bfce140ada5ca1ac556f79"},
+    {file = "wrapt-1.13.3-cp38-cp38-win_amd64.whl", hash = "sha256:7dde79d007cd6dfa65afe404766057c2409316135cb892be4b1c768e3f3a11cb"},
+    {file = "wrapt-1.13.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:981da26722bebb9247a0601e2922cedf8bb7a600e89c852d063313102de6f2cb"},
+    {file = "wrapt-1.13.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:705e2af1f7be4707e49ced9153f8d72131090e52be9278b5dbb1498c749a1e32"},
+    {file = "wrapt-1.13.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:25b1b1d5df495d82be1c9d2fad408f7ce5ca8a38085e2da41bb63c914baadff7"},
+    {file = "wrapt-1.13.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:77416e6b17926d953b5c666a3cb718d5945df63ecf922af0ee576206d7033b5e"},
+    {file = "wrapt-1.13.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:865c0b50003616f05858b22174c40ffc27a38e67359fa1495605f96125f76640"},
+    {file = "wrapt-1.13.3-cp39-cp39-win32.whl", hash = "sha256:0a017a667d1f7411816e4bf214646d0ad5b1da2c1ea13dec6c162736ff25a374"},
+    {file = "wrapt-1.13.3-cp39-cp39-win_amd64.whl", hash = "sha256:81bd7c90d28a4b2e1df135bfbd7c23aee3050078ca6441bead44c42483f9ebfb"},
+    {file = "wrapt-1.13.3.tar.gz", hash = "sha256:1fea9cd438686e6682271d36f3481a9f3636195578bab9ca3382e2f5f01fc185"},
 ]
 yarl = [
     {file = "yarl-1.7.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f2a8508f7350512434e41065684076f640ecce176d262a7d54f0da41d99c5a95"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ flask-cors = "^3.0.10"
 cairo-lang = "0.6.2"
 
 [tool.poetry.dev-dependencies]
+pylint = "^2.12.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/scripts/hardhat.config.dockerized.ts
+++ b/scripts/hardhat.config.dockerized.ts
@@ -1,0 +1,15 @@
+import "@shardlabs/starknet-hardhat-plugin";
+
+module.exports = {
+    cairo: {
+        version: "latest"
+    },
+    networks: {
+        devnet: {
+            url: "http://localhost:5000"
+        }
+    },
+    mocha: {
+        starknetNetwork: "devnet"
+    }
+}

--- a/scripts/hardhat.config.venv.ts
+++ b/scripts/hardhat.config.venv.ts
@@ -1,0 +1,15 @@
+import "@shardlabs/starknet-hardhat-plugin";
+
+module.exports = {
+    cairo: {
+        venv: "active"
+    },
+    networks: {
+        devnet: {
+            url: "http://localhost:5000"
+        }
+    },
+    mocha: {
+        starknetNetwork: "devnet"
+    }
+}

--- a/scripts/test_plugin.sh
+++ b/scripts/test_plugin.sh
@@ -43,4 +43,9 @@ npx hardhat starknet-deploy \
 | result_assertion
 echo "Finished deploy-call procedure"
 
-npx hardhat test test/quick-test.ts
+if [ -f "TEST_FILE" ]; then
+    echo "Invalid TEST_FILE provided"
+    exit 1
+fi
+
+npx hardhat test "$TEST_FILE"

--- a/scripts/test_plugin.sh
+++ b/scripts/test_plugin.sh
@@ -31,9 +31,9 @@ function result_assertion() {
 }
 
 cd starknet-hardhat-example
-# npx hardhat starknet-compile <- Already executed in setup_example.sh
+# npx hardhat starknet-compile --config "$HARDHAT_CONFIG" <- Already executed in setup_example.sh
 # devnet already defined in config as localhost:5000
-npx hardhat starknet-deploy \
+npx hardhat starknet-deploy --config "$HARDHAT_CONFIG" \
     starknet-artifacts/contracts/contract.cairo \
     --starknet-network devnet \
     --inputs 10 \
@@ -42,4 +42,4 @@ npx hardhat starknet-deploy \
 | result_assertion
 echo "Finished deploy-call procedure"
 
-npx hardhat test
+npx hardhat test test/quick-test.ts --config "$HARDHAT_CONFIG"

--- a/scripts/test_plugin.sh
+++ b/scripts/test_plugin.sh
@@ -31,9 +31,10 @@ function result_assertion() {
 }
 
 cd starknet-hardhat-example
-# npx hardhat starknet-compile --config "$HARDHAT_CONFIG" <- Already executed in setup_example.sh
+mv "$HARDHAT_CONFIG_FILE" hardhat.config.ts
+# npx hardhat starknet-compile <- Already executed in setup_example.sh
 # devnet already defined in config as localhost:5000
-npx hardhat starknet-deploy --config "$HARDHAT_CONFIG" \
+npx hardhat starknet-deploy \
     starknet-artifacts/contracts/contract.cairo \
     --starknet-network devnet \
     --inputs 10 \
@@ -42,4 +43,4 @@ npx hardhat starknet-deploy --config "$HARDHAT_CONFIG" \
 | result_assertion
 echo "Finished deploy-call procedure"
 
-npx hardhat test test/quick-test.ts --config "$HARDHAT_CONFIG"
+npx hardhat test test/quick-test.ts

--- a/starknet_devnet/__init__.py
+++ b/starknet_devnet/__init__.py
@@ -1,1 +1,5 @@
+"""
+Contains the server implementation and its utility classes and functions.
+"""
+
 __version__ = "0.1.10"

--- a/starknet_devnet/adapt.py
+++ b/starknet_devnet/adapt.py
@@ -1,3 +1,7 @@
+"""
+Contains functions for adapting Starknet function input and output.
+"""
+
 from starknet_devnet.util import StarknetDevnetException
 
 def adapt_calldata(calldata, expected_inputs, types):
@@ -24,9 +28,8 @@ def adapt_calldata(calldata, expected_inputs, types):
                 # Last element was array length (0), it's replaced with the array itself
                 adapted_calldata[-1] = []
                 continue
-            else:
-                message = f"Too few function arguments provided: {len(calldata)}."
-                raise StarknetDevnetException(message=message)
+            message = f"Too few function arguments provided: {len(calldata)}."
+            raise StarknetDevnetException(message=message)
         input_value = calldata[calldata_i]
 
         if input_type == "felt*":
@@ -81,8 +84,8 @@ def adapt_output_rec(received, ret):
     if isinstance(received, list):
         ret.append(hex(len(received)))
     try:
-        for el in received:
-            adapt_output_rec(el, ret)
+        for element in received:
+            adapt_output_rec(element, ret)
     except TypeError:
         ret.append(hex(received))
 
@@ -95,7 +98,8 @@ def generate_complex(calldata, calldata_i: int, input_type: str, types):
     The `calldata_i` is incremented according to how many `calldata` members were consumed.
     `types` is a dict that maps a type's name to its specification.
 
-    Returns the `calldata` converted to the type specified by `input_type` (tuple if struct or tuple, number). Also returns the incremented `calldata_i`.
+    Returns the `calldata` converted to the type specified by `input_type` (tuple if struct or tuple, number).
+    Also returns the incremented `calldata_i`.
     """
 
     if input_type == "felt":

--- a/starknet_devnet/contract_wrapper.py
+++ b/starknet_devnet/contract_wrapper.py
@@ -1,7 +1,31 @@
+"""
+Contains code for wrapping StarknetContract instances.
+"""
+
+from dataclasses import dataclass
+from typing import List
+
+from starkware.starknet.public.abi import get_selector_from_name
 from starkware.starknet.services.api.contract_definition import ContractDefinition
 from starkware.starknet.testing.contract import StarknetContract
 
+from starknet_devnet.adapt import adapt_calldata, adapt_output
+from starknet_devnet.util import Choice, StarknetDevnetException
+
+def extract_types(abi):
+    """
+    Extracts the types (structs) used in the contract whose ABI is provided.
+    """
+
+    structs = [entry for entry in abi if entry["type"] == "struct"]
+    type_dict = { struct["name"]: struct for struct in structs }
+    return type_dict
+
+@dataclass
 class ContractWrapper:
+    """
+    Wraps a StarknetContract, storing its types and code for later use.
+    """
     def __init__(self, contract: StarknetContract, contract_definition: ContractDefinition):
         self.contract: StarknetContract = contract
         self.code: dict = {
@@ -9,13 +33,30 @@ class ContractWrapper:
             "bytecode": [hex(el) for el in contract_definition.program.data]
         }
 
-        self.types: dict = self.extract_types(contract_definition.abi)
+        self.types: dict = extract_types(contract_definition.abi)
 
-    def extract_types(self, abi):
+    async def call_or_invoke(self, choice: Choice, entry_point_selector: int, calldata: List[int], signature: List[int]):
         """
-        Extracts the types (structs) used in the contract whose ABI is provided.
+        Depending on `choice`, performs the call or invoke of the function
+        identified with `entry_point_selector`, potentially passing in `calldata` and `signature`.
         """
+        function_mapping = self.contract._abi_function_mapping # pylint: disable=protected-access
+        for method_name in function_mapping:
+            selector = get_selector_from_name(method_name)
+            if selector == entry_point_selector:
+                try:
+                    method = getattr(self.contract, method_name)
+                except NotImplementedError as nie:
+                    raise StarknetDevnetException from nie
+                function_abi = function_mapping[method_name]
+                break
+        else:
+            raise StarknetDevnetException(message=f"Illegal method selector: {entry_point_selector}.")
 
-        structs = [entry for entry in abi if entry["type"] == "struct"]
-        type_dict = { struct["name"]: struct for struct in structs }
-        return type_dict
+        adapted_calldata = adapt_calldata(calldata, function_abi["inputs"], self.types)
+
+        prepared = method(*adapted_calldata)
+        called = getattr(prepared, choice.value)
+        executed = await called(signature=signature)
+
+        return adapt_output(executed.result)

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -1,3 +1,9 @@
+"""
+A server exposing Starknet functionalities as API endpoints.
+"""
+
+import os
+
 from flask import Flask, request, jsonify, abort
 from flask.wrappers import Response
 from flask_cors import CORS
@@ -6,9 +12,9 @@ from starkware.starknet.services.api.gateway.transaction import InvokeFunction, 
 from starkware.starknet.definitions.transaction_type import TransactionType
 from starkware.starkware_utils.error_handling import StarkErrorCode, StarkException
 from werkzeug.datastructures import MultiDict
+
 from .util import TxStatus, custom_int, fixed_length_hex, parse_args
 from .starknet_wrapper import Choice, StarknetWrapper
-import os
 
 app = Flask(__name__)
 CORS(app)
@@ -19,6 +25,7 @@ starknet_wrapper = StarknetWrapper()
 @app.route("/gateway/is_alive", methods=["GET"])
 @app.route("/feeder_gateway/is_alive", methods=["GET"])
 def is_alive():
+    """Health check endpoint."""
     return "Alive!!!"
 
 @app.route("/gateway/add_transaction", methods=["POST"])
@@ -49,8 +56,8 @@ async def add_transaction():
                 contract_address_salt=deploy_transaction.contract_address_salt,
                 constructor_calldata=deploy_transaction.constructor_calldata
             )
-        except StarkException as e:
-            error_message = e.message
+        except StarkException as err:
+            error_message = err.message
             status = TxStatus.REJECTED
 
         transaction_hash = await starknet_wrapper.store_deploy_transaction(
@@ -72,8 +79,8 @@ async def add_transaction():
                 calldata=transaction.calldata,
                 signature=transaction.signature
             )
-        except StarkException as e:
-            error_message = e.message
+        except StarkException as err:
+            error_message = err.message
             status = TxStatus.REJECTED
 
         transaction_hash = await starknet_wrapper.store_invoke_transaction(
@@ -96,6 +103,7 @@ async def add_transaction():
 
 @app.route("/feeder_gateway/get_contract_addresses", methods=["GET"])
 def get_contract_addresses():
+    """Endpoint that returns an object containing the addresses of key system components."""
     return "Not implemented", 501
 
 @app.route("/feeder_gateway/call_contract", methods=["POST"])
@@ -114,25 +122,26 @@ async def call_contract():
             calldata=call_specifications.calldata,
             signature=call_specifications.signature
         )
-    except StarkException as e:
+    except StarkException as err:
         # code 400 would make more sense, but alpha returns 500
-        abort(Response(e.message, 500))
+        abort(Response(err.message, 500))
 
     return jsonify(result_dict)
 
-def check_block_hash(request_args: MultiDict):
+def _check_block_hash(request_args: MultiDict):
     block_hash = request_args.get("blockHash", type=custom_int)
     if block_hash is not None:
         print("Specifying a block by its hash is not supported. All interaction is done with the latest block.")
 
 @app.route("/feeder_gateway/get_block", methods=["GET"])
 async def get_block():
+    """Endpoint for retrieving blocks identified by their hash or number."""
     block_hash = request.args.get("blockHash")
     block_number = request.args.get("blockNumber", type=custom_int)
     try:
         result_dict = starknet_wrapper.get_block(block_hash=block_hash, block_number=block_number)
-    except StarkException as e:
-        abort(Response(e.message, 500))
+    except StarkException as err:
+        abort(Response(err.message, 500))
     return jsonify(result_dict)
 
 @app.route("/feeder_gateway/get_code", methods=["GET"])
@@ -140,7 +149,7 @@ def get_code():
     """
     Returns the ABI and bytecode of the contract whose contractAddress is provided.
     """
-    check_block_hash(request.args)
+    _check_block_hash(request.args)
 
     contract_address = request.args.get("contractAddress", type=custom_int)
     result_dict = starknet_wrapper.get_code(contract_address)
@@ -148,7 +157,8 @@ def get_code():
 
 @app.route("/feeder_gateway/get_storage_at", methods=["GET"])
 async def get_storage_at():
-    check_block_hash(request.args)
+    """Endpoint for returning the storage identified by `key` from the contract at """
+    _check_block_hash(request.args)
 
     contract_address = request.args.get("contractAddress", type=custom_int)
     key = request.args.get("key", type=custom_int)
@@ -185,6 +195,7 @@ def get_transaction_receipt():
     return "Not implemented", 501
 
 def main():
+    """The main function, used when running this module directly."""
     # reduce startup logging
     os.environ['WERKZEUG_RUN_MAIN'] = 'true'
 

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -109,7 +109,7 @@ class StarknetWrapper:
         Performs `ContractWrapper.call_or_invoke` on the contract at `contract_address`.
         """
         contract_wrapper = self.__get_contract_wrapper(contract_address)
-        result = contract_wrapper.call_or_invoke(choice, contract_address, entry_point_selector, calldata, signature)
+        result = contract_wrapper.call_or_invoke(choice, entry_point_selector, calldata, signature)
         await self.__update_state()
         return { "result": result }
 

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -109,7 +109,7 @@ class StarknetWrapper:
         Performs `ContractWrapper.call_or_invoke` on the contract at `contract_address`.
         """
         contract_wrapper = self.__get_contract_wrapper(contract_address)
-        result = contract_wrapper.call_or_invoke(choice, entry_point_selector, calldata, signature)
+        result = await contract_wrapper.call_or_invoke(choice, entry_point_selector, calldata, signature)
         await self.__update_state()
         return { "result": result }
 

--- a/starknet_devnet/util.py
+++ b/starknet_devnet/util.py
@@ -1,3 +1,7 @@
+"""
+Utility functions used across the project.
+"""
+
 from enum import Enum, auto
 import argparse
 
@@ -27,7 +31,18 @@ class TxStatus(Enum):
     ACCEPTED_ON_L1 = auto()
     """The transaction was accepted on-chain."""
 
+
+class Choice(Enum):
+    """Enumerates ways of interacting with a Starknet function."""
+    CALL = "call"
+    INVOKE = "invoke"
+
+
 def custom_int(arg: str) -> str:
+    """
+    Converts the argument to an integer.
+    Conversion base is 16 if `arg` starts with `0x`, otherwise `10`.
+    """
     base = 16 if arg.startswith("0x") else 10
     return int(arg, base)
 
@@ -38,10 +53,12 @@ def fixed_length_hex(arg: int) -> str:
 
     return f"0x{arg:064x}"
 
-
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 5000
 def parse_args():
+    """
+    Parses CLI arguments.
+    """
     parser = argparse.ArgumentParser(description="Run a local instance of Starknet devnet")
     parser.add_argument(
         "-v", "--version",
@@ -64,5 +81,9 @@ def parse_args():
     return parser.parse_args()
 
 class StarknetDevnetException(StarkException):
+    """
+    Exception raised across the project.
+    Indicates the raised issue is devnet-related.
+    """
     def __init__(self, code=500, message=None):
         super().__init__(code=code, message=message)


### PR DESCRIPTION
## Usage
- This PR contains no usage changes.

## Dev
- Adds a linting step to the CI/CD workflow:
  - Performed with `pylint` and configured through `.pylintrc`.
  - Make necessary changes to conform to the standards set by the linter.
- Add testing with plugin using a venv:
  - So far only the dockerized plugin version was tested.
  - Dockerized and venv test are specified as separate steps in job `test`.
  - ~~Rely on hardhat's --config option for specifying which config file to use.~~
- Instead of running all tests in `starknet-hardhat-example`, run only `quick-test.ts`.