### PR TITLE
Add partial receipt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,12 @@ If you don't specify the `HOST` part, the server will indeed be available on all
   - `get_transaction`
   - `invoke`
   - `tx_status`
+  - `get_transaction_receipt`:
+    - returns complete data for invoke transactions
+    - returns partial data for deploy transactions
 - The following Starknet CLI commands are **not** supported:
   - `get_block` - transactions are not organized into blocks
   - `get_contract_addresses` - L1-L2 interaction is currently not supported
-  - `get_transaction_receipt` - soon to be supported
 
 ## Hardhat integration
 - If you're using [the Hardhat plugin](https://github.com/Shard-Labs/starknet-hardhat-plugin), see [here](https://github.com/Shard-Labs/starknet-hardhat-plugin#testing-network) on how to edit its config file to integrate this devnet.

--- a/receipt.json
+++ b/receipt.json
@@ -1,9 +1,0 @@
-{
-    "block_hash": "0x0",
-    "block_number": 0,
-    "execution_resources": {},
-    "l2_to_l1_messages": [],
-    "status": "ACCEPTED_ON_L2",
-    "transaction_hash": "0x0",
-    "transaction_index": 0
-}

--- a/receipt.json
+++ b/receipt.json
@@ -1,0 +1,9 @@
+{
+    "block_hash": "0x0",
+    "block_number": 0,
+    "execution_resources": {},
+    "l2_to_l1_messages": [],
+    "status": "ACCEPTED_ON_L2",
+    "transaction_hash": "0x0",
+    "transaction_index": 0
+}

--- a/scripts/test_cli.sh
+++ b/scripts/test_cli.sh
@@ -46,8 +46,9 @@ fi
 balance_key=916907772491729262376534102982219947830828984996257231353398618781993312401
 scripts/test_storage.sh "$address" "$balance_key" 0x0
 
-# check block after deployment
+# check block and receipt after deployment
 scripts/test_block.sh 0 "$deploy_tx_hash"
+scripts/test_receipt.sh 0 "$deploy_tx_hash"
 
 # check code
 scripts/test_code.sh "$address"
@@ -71,5 +72,6 @@ fi
 # check storage after increase
 scripts/test_storage.sh "$address" "$balance_key" 0x1e
 
-# check block after increase
+# check block and receipt after increase
 scripts/test_block.sh 1 "$invoke_tx_hash"
+scripts/test_receipt.sh 1 "$invoke_tx_hash"

--- a/scripts/test_receipt.sh
+++ b/scripts/test_receipt.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+source scripts/settings.ini
+[ -f .env ] && source .env
+
+USAGE="$0: <BLOCK_NUMBER> <TX_HASH>"
+
+if [ "$#" -ne 2 ]; then
+    echo "$USAGE"
+    exit 1
+fi
+
+BLOCK_NUMBER="$1"
+TX_HASH="$2"
+
+RECEIPT_FILE=receipt.json
+starknet get_transaction_receipt --hash "$TX_HASH" --feeder_gateway_url "$FEEDER_GATEWAY_URL" > "$RECEIPT_FILE"
+
+props_not_found=""
+for prop in block_hash block_number execution_resources l2_to_l1_messages status transaction_hash transaction_index; do
+    jq --exit-status ".$prop" "$RECEIPT_FILE" 2>&1 > /dev/null  || props_not_found="$props_not_found $prop"
+done
+
+if [ -n "$props_not_found" ]; then
+    echo "Receipt props not found:$props_not_found"
+    exit 1
+fi
+
+function compare_json() {
+    prop="$1"
+    expected_value="$2"
+    actual_value=$(jq ".$prop" "$RECEIPT_FILE")
+    if [ "$actual_value" = "$expected_value" ]; then
+        echo "Correct $prop"
+    else
+        echo "Incorrect $prop"
+        echo "Expected: $expected_value"
+        echo "Actual: $actual_value"
+        exit 2
+    fi
+}
+
+compare_json block_number "$BLOCK_NUMBER"
+compare_json transaction_hash "$TX_HASH"
+compare json transaction_index 0

--- a/scripts/test_receipt.sh
+++ b/scripts/test_receipt.sh
@@ -43,5 +43,5 @@ function compare_json() {
 }
 
 compare_json block_number "$BLOCK_NUMBER"
-compare_json transaction_hash "$TX_HASH"
-compare json transaction_index 0
+compare_json transaction_hash "\"$TX_HASH\""
+compare_json transaction_index 0

--- a/starknet_devnet/adapt.py
+++ b/starknet_devnet/adapt.py
@@ -51,7 +51,7 @@ def adapt_calldata(calldata, expected_inputs, types):
             calldata_i += 1
 
         else: # struct
-            generated_complex, calldata_i = generate_complex(calldata, calldata_i, input_type, types)
+            generated_complex, calldata_i = _generate_complex(calldata, calldata_i, input_type, types)
             adapted_calldata.append(generated_complex)
 
         last_name = input_name
@@ -73,23 +73,19 @@ def adapt_output(received):
     """
 
     ret = []
-    adapt_output_rec(received, ret)
+    _adapt_output_rec(received, ret)
     return ret
 
-def adapt_output_rec(received, ret):
-    """
-    Recursion called by adapt_output.
-    """
-
+def _adapt_output_rec(received, ret):
     if isinstance(received, list):
         ret.append(hex(len(received)))
     try:
         for element in received:
-            adapt_output_rec(element, ret)
+            _adapt_output_rec(element, ret)
     except TypeError:
         ret.append(hex(received))
 
-def generate_complex(calldata, calldata_i: int, input_type: str, types):
+def _generate_complex(calldata, calldata_i: int, input_type: str, types):
     """
     Converts members of `calldata` to a more complex type specified by `input_type`:
     - puts members of a struct into a tuple
@@ -115,7 +111,7 @@ def generate_complex(calldata, calldata_i: int, input_type: str, types):
         members = [entry["type"] for entry in struct["members"]]
 
     for member in members:
-        generated_complex, calldata_i = generate_complex(calldata, calldata_i, member, types)
+        generated_complex, calldata_i = _generate_complex(calldata, calldata_i, member, types)
         arr.append(generated_complex)
 
     return tuple(arr), calldata_i

--- a/starknet_devnet/contract_wrapper.py
+++ b/starknet_devnet/contract_wrapper.py
@@ -8,6 +8,7 @@ from typing import List
 from starkware.starknet.public.abi import get_selector_from_name
 from starkware.starknet.services.api.contract_definition import ContractDefinition
 from starkware.starknet.testing.contract import StarknetContract
+from starkware.starknet.testing.objects import StarknetTransactionExecutionInfo
 
 from starknet_devnet.adapt import adapt_calldata, adapt_output
 from starknet_devnet.util import Choice, StarknetDevnetException
@@ -57,6 +58,5 @@ class ContractWrapper:
 
         prepared = method(*adapted_calldata)
         called = getattr(prepared, choice.value)
-        executed = await called(signature=signature)
-
-        return adapt_output(executed.result)
+        execution_info: StarknetTransactionExecutionInfo = await called(signature=signature)
+        return adapt_output(execution_info.result), execution_info

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -37,7 +37,7 @@ def _generate_transaction_receipt_basis(status: TxStatus, transaction_hash: str,
         "l2_to_l1_messages": execution_info.l2_to_l1_messages,
         "status": status.name,
         "transaction_hash": transaction_hash,
-        "transcation_index": 0 # always the first (and only) tx in the block
+        "transaction_index": 0 # always the first (and only) tx in the block
     }
 
 class StarknetWrapper:
@@ -218,7 +218,6 @@ class StarknetWrapper:
         """
         Generates a block and stores it to blocks and hash2block. The block contains just the passed transaction.
         The `transaction` dict should also contain a key `transaction`.
-        Returns (block_hash, block_number).
         """
 
         block_number = len(self.__blocks)
@@ -241,7 +240,6 @@ class StarknetWrapper:
 
         self.__blocks.append(block)
         self.__hash2block[int(block_hash, 16)] = block
-        return block_hash, block_number
 
     def get_block(self, block_hash: str=None, block_number: int=None):
         """Returns the block identified either by its `block_hash` or `block_number`."""

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -11,12 +11,34 @@ from starkware.starknet.business_logic.internal_transaction import InternalDeplo
 from starkware.starknet.business_logic.state import CarriedState
 from starkware.starknet.services.api.gateway.transaction import InvokeFunction
 from starkware.starknet.testing.starknet import Starknet
+from starkware.starknet.testing.objects import StarknetTransactionExecutionInfo
 from starkware.starknet.definitions.error_codes import StarknetErrorCode
 from starkware.starknet.definitions.transaction_type import TransactionType
 from starkware.starkware_utils.error_handling import StarkException
 
-from .util import Choice, StarknetDevnetException, TxStatus, fixed_length_hex
+from .util import Choice, StarknetDevnetException, TxStatus, fixed_length_hex, DummyExecutionInfo
 from .contract_wrapper import ContractWrapper
+
+
+def _generate_transaction_basis(contract_address: str, status: TxStatus, transaction_hash: str, **transaction_details: dict):
+    return {
+        "status": status.name,
+        "transaction": {
+            "contract_address": fixed_length_hex(contract_address),
+            "transaction_hash": transaction_hash,
+            **transaction_details
+        },
+        "transaction_index": 0 # always the first (and only) tx in the block
+    }
+
+def _generate_transaction_receipt_basis(status: TxStatus, transaction_hash: str, execution_info: StarknetTransactionExecutionInfo):
+    return {
+        "execution_resources": execution_info.call_info.cairo_usage,
+        "l2_to_l1_messages": execution_info.l2_to_l1_messages,
+        "status": status.name,
+        "transaction_hash": transaction_hash,
+        "transcation_index": 0 # always the first (and only) tx in the block
+    }
 
 class StarknetWrapper:
     """
@@ -29,6 +51,9 @@ class StarknetWrapper:
 
         self.__transactions = []
         """A chronological list of transactions."""
+
+        self.__transaction_receipts = []
+        """A chronological list of transaction receipts."""
 
         self.__hash2block = {}
         """Maps block hash to block."""
@@ -90,8 +115,7 @@ class StarknetWrapper:
 
     async def deploy(self, transaction: InternalDeploy):
         """
-        Deploys the contract whose definition is provided and returns deployment address in hex form.
-        The other returned object is present to conform to a past version of call_or_invoke, but will be removed in future versions.
+        Deploys the contract specified with `transaction` and returns tx hash in hex.
         """
 
         starknet = await self.get_starknet()
@@ -111,6 +135,7 @@ class StarknetWrapper:
         transaction_hash = await self.__store_deploy_transaction(
             transaction,
             status=status,
+            execution_info=DummyExecutionInfo(),
             error_message=error_message
         )
 
@@ -121,10 +146,13 @@ class StarknetWrapper:
     async def call_or_invoke(self, choice: Choice, specifications: InvokeFunction):
         """
         Performs `ContractWrapper.call_or_invoke` on the contract at `contract_address`.
-        if `choice` is INVOKE, updates the state.
+        If `choice` is INVOKE, updates the state.
+        Returns a tuple of:
+        - `dict` with `"result"`, holding the adapted result
+        - `execution_info`
         """
         contract_wrapper = self.__get_contract_wrapper(specifications.contract_address)
-        result = await contract_wrapper.call_or_invoke(
+        adapted_result, execution_info = await contract_wrapper.call_or_invoke(
             choice,
             entry_point_selector=specifications.entry_point_selector,
             calldata=specifications.calldata,
@@ -134,7 +162,7 @@ class StarknetWrapper:
         if choice == Choice.INVOKE:
             await self.__update_state()
 
-        return { "result": result }
+        return { "result": adapted_result }, execution_info
 
     def __is_transaction_hash_legal(self, transaction_hash_int: int) -> bool:
         return 0 <= transaction_hash_int < len(self.__transactions)
@@ -174,15 +202,31 @@ class StarknetWrapper:
             "transaction_hash": transaction_hash
         }
 
-    async def __generate_block(self, transaction: dict):
+    def get_transaction_receipt(self, transaction_hash: str):
+        """Returns the transaction receipt of the transaction identified by `transaction_hash`."""
+
+        transaction_hash_int = int(transaction_hash, 16)
+        if self.__is_transaction_hash_legal(transaction_hash_int):
+            return self.__transaction_receipts[transaction_hash_int]
+        return {
+            "l2_to_l1_messages": [],
+            "status": TxStatus.NOT_RECEIVED.name,
+            "transaction_hash": transaction_hash
+        }
+
+    async def __generate_block(self, transaction: dict, receipt: dict):
         """
         Generates a block and stores it to blocks and hash2block. The block contains just the passed transaction.
-        Returns (block_hash, block_number)
+        The `transaction` dict should also contain a key `transaction`.
+        Returns (block_hash, block_number).
         """
 
         block_number = len(self.__blocks)
         block_hash = hex(block_number)
         state_root = await self.__get_state_root()
+
+        transaction["block_hash"] = receipt["block_hash"] = block_hash
+        transaction["block_number"] = receipt["block_number"] = block_number
 
         block = {
             "block_hash": block_hash,
@@ -191,8 +235,8 @@ class StarknetWrapper:
             "state_root": state_root,
             "status": TxStatus.ACCEPTED_ON_L2.name,
             "timestamp": int(time.time()),
-            "transaction_receipts": ["Not yet supported!"],
-            "transactions": [transaction],
+            "transaction_receipts": [receipt],
+            "transactions": [transaction["transaction"]],
         }
 
         self.__blocks.append(block)
@@ -230,50 +274,51 @@ class StarknetWrapper:
         message = "Requested the latest block, but there are no blocks so far."
         raise StarknetDevnetException(message=message)
 
-    async def __store_transaction(self, contract_address: str, status: TxStatus, error_message: str=None, **transaction_details: dict):
+    async def __store_transaction(self, contract_address: str, status: TxStatus,
+        execution_info: StarknetTransactionExecutionInfo, error_message: str=None, **transaction_details: dict
+    ):
         new_id = len(self.__transactions)
         hex_new_id = hex(new_id)
 
-        transaction = {
-            "status": status.name,
-            "transaction": {
-                "contract_address": fixed_length_hex(contract_address),
-                "transaction_hash": hex_new_id,
-                **transaction_details
-            },
-            "transaction_index": 0 # always the first (and only) tx in the block
-        }
+        transaction = _generate_transaction_basis(contract_address, status, hex_new_id, **transaction_details)
+        receipt = _generate_transaction_receipt_basis(status, hex_new_id, execution_info)
 
         if status == TxStatus.REJECTED:
-            transaction["transaction_failure_reason"] = {
+            failure_key = "transaction_failure_reason"
+            transaction[failure_key] = receipt[failure_key] = {
                 "code": StarknetErrorCode.TRANSACTION_FAILED.name,
                 "error_message": error_message,
                 "tx_id": new_id
             }
         else:
-            block_hash, block_number = await self.__generate_block(transaction["transaction"])
-            transaction["block_hash"] = block_hash
-            transaction["block_number"] = block_number
+            await self.__generate_block(transaction, receipt)
 
         self.__transactions.append(transaction)
+        self.__transaction_receipts.append(receipt)
         return hex_new_id
 
-    async def __store_deploy_transaction(self, transaction: InternalDeploy, status: TxStatus, error_message: str=None):
+    async def __store_deploy_transaction(self, transaction: InternalDeploy, status: TxStatus,
+        execution_info: StarknetTransactionExecutionInfo, error_message: str=None
+    ):
         """Stores the provided data as a deploy transaction in `self.transactions`."""
         return await self.__store_transaction(
             transaction.contract_address,
             status,
+            execution_info,
             error_message,
             type=TransactionType.DEPLOY.name,
             constructor_calldata=[str(arg) for arg in transaction.constructor_calldata],
             contract_address_salt=hex(transaction.contract_address_salt)
         )
 
-    async def store_invoke_transaction(self, transaction: InvokeFunction, status: TxStatus, error_message: str=None):
+    async def store_invoke_transaction(self, transaction: InvokeFunction, status: TxStatus,
+        execution_info: StarknetTransactionExecutionInfo, error_message: str=None
+    ):
         """Stores the provided data as an invoke transaction in `self.transactions`."""
         return await self.__store_transaction(
             transaction.contract_address,
             status,
+            execution_info,
             error_message,
             type=TransactionType.INVOKE_FUNCTION.name,
             calldata=[str(arg) for arg in transaction.calldata],

--- a/starknet_devnet/util.py
+++ b/starknet_devnet/util.py
@@ -2,6 +2,7 @@
 Utility functions used across the project.
 """
 
+from dataclasses import dataclass
 from enum import Enum, auto
 import argparse
 
@@ -87,3 +88,18 @@ class StarknetDevnetException(StarkException):
     """
     def __init__(self, code=500, message=None):
         super().__init__(code=code, message=message)
+
+@dataclass
+class DummyCallInfo:
+    """Used temporarily until contracts received from starknet.deploy include their own execution_info.call_info"""
+    def __init__(self):
+        self.cairo_usage = {}
+
+@dataclass
+class DummyExecutionInfo:
+    """Used temporarily until contracts received from starknet.deploy include their own execution_info."""
+    def __init__(self):
+        self.call_info = DummyCallInfo()
+        self.retdata = []
+        self.internal_calls = []
+        self.l2_to_l1_messages = []


### PR DESCRIPTION
## Usage
- Add partial support for `starknet get_transaction_receipt` command:
  - `invoke` transactions are fully supported
  - `deploy` transactions temporarily return empty data because they don't provide `execution_info`, which is necessary to extract the receipt data.

## Dev
- Update testing accordingly.