### PR TITLE
Refactor to prepare for forking

### DIFF
--- a/starknet_devnet/origin.py
+++ b/starknet_devnet/origin.py
@@ -1,5 +1,60 @@
+"""
+Contains classes that provide the abstraction of L2 blockchain.
+"""
+
+from starknet_devnet.util import TxStatus
+
+
 class Origin:
-    pass
+    """
+    Abstraction of an L2 blockchain.
+    """
+
+    def get_transaction_status(self, transaction_hash: str):
+        """Returns the status of the transaction."""
+        raise NotImplementedError
+
+    def get_transaction(self, transaction_hash: str):
+        """Returns the transaction object."""
+        raise NotImplementedError
+
+    def get_block(self, block_hash: str, block_number: int):
+        """Returns the block identified with either its hash or its number."""
+        raise NotImplementedError
+
+    def get_code(self, contract_address: int) -> dict:
+        """Returns the code of the contract."""
+        raise NotImplementedError
+
+    def get_storage_at(self, contract_address: int, key: int) -> str:
+        """Returns the storage identified with `key` at `contract_address`."""
+        raise NotImplementedError
+
 
 class NullOrigin(Origin):
-    pass
+    """
+    A default class to comply with the Origin interface.
+    """
+
+    def get_transaction_status(self, transaction_hash: str):
+        return {
+            "tx_status": TxStatus.NOT_RECEIVED.name
+        }
+
+    def get_transaction(self, transaction_hash: str):
+        return {
+            "status": TxStatus.NOT_RECEIVED.name,
+            "transaction_hash": transaction_hash
+        }
+
+    def get_block(self, block_hash: str, block_number: int):
+        raise NotImplementedError
+
+    def get_code(self, contract_address: int):
+        return {
+            "abi": {},
+            "bytecode": []
+        }
+
+    def get_storage_at(self, contract_address: int, key: int) -> str:
+        return hex(0)

--- a/starknet_devnet/origin.py
+++ b/starknet_devnet/origin.py
@@ -2,7 +2,7 @@
 Contains classes that provide the abstraction of L2 blockchain.
 """
 
-from starknet_devnet.util import TxStatus
+from starknet_devnet.util import StarknetDevnetException, TxStatus
 
 
 class Origin:
@@ -18,8 +18,12 @@ class Origin:
         """Returns the transaction object."""
         raise NotImplementedError
 
-    def get_block(self, block_hash: str, block_number: int):
-        """Returns the block identified with either its hash or its number."""
+    def get_block_by_hash(self, block_hash: str):
+        """Returns the block identified with either its hash."""
+        raise NotImplementedError
+
+    def get_block_by_number(self, block_number: int):
+        """Returns the block identified with either its number or the latest block if no number provided."""
         raise NotImplementedError
 
     def get_code(self, contract_address: int) -> dict:
@@ -28,6 +32,10 @@ class Origin:
 
     def get_storage_at(self, contract_address: int, key: int) -> str:
         """Returns the storage identified with `key` at `contract_address`."""
+        raise NotImplementedError
+
+    def get_number_of_blocks(self):
+        """Returns the number of blocks stored so far"""
         raise NotImplementedError
 
 
@@ -47,8 +55,13 @@ class NullOrigin(Origin):
             "transaction_hash": transaction_hash
         }
 
-    def get_block(self, block_hash: str, block_number: int):
-        raise NotImplementedError
+    def get_block_by_hash(self, block_hash: str):
+        message=f"Block hash not found; got: {block_hash}."
+        raise StarknetDevnetException(message=message)
+
+    def get_block_by_number(self, block_number: int):
+        message = "Requested the latest block, but there are no blocks so far."
+        raise StarknetDevnetException(message=message)
 
     def get_code(self, contract_address: int):
         return {
@@ -58,3 +71,37 @@ class NullOrigin(Origin):
 
     def get_storage_at(self, contract_address: int, key: int) -> str:
         return hex(0)
+
+    def get_number_of_blocks(self):
+        return 0
+
+
+class ForkedOrigin(Origin):
+    """
+    Abstracts an origin that the devnet was forked from.
+    """
+
+    def __init__(self, url):
+        self.url = url
+        self.number_of_blocks = ...
+
+    def get_transaction_status(self, transaction_hash: str):
+        raise NotImplementedError
+
+    def get_transaction(self, transaction_hash: str):
+        raise NotImplementedError
+
+    def get_block_by_hash(self, block_hash: str):
+        raise NotImplementedError
+
+    def get_block_by_number(self, block_number: int):
+        raise NotImplementedError
+
+    def get_code(self, contract_address: int) -> dict:
+        raise NotImplementedError
+
+    def get_storage_at(self, contract_address: int, key: int) -> str:
+        raise NotImplementedError
+
+    def get_number_of_blocks(self):
+        return self.number_of_blocks

--- a/starknet_devnet/origin.py
+++ b/starknet_devnet/origin.py
@@ -1,0 +1,5 @@
+class Origin:
+    pass
+
+class NullOrigin(Origin):
+    pass

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -176,5 +176,5 @@ os.environ['WERKZEUG_RUN_MAIN'] = 'true'
 
 args = parse_args()
 origin = Origin(args.fork) if args.fork else NullOrigin()
-starknet_wrapper = StarknetWrapper()
+starknet_wrapper = StarknetWrapper(origin)
 app.run(**vars(args))

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -15,11 +15,10 @@ from werkzeug.datastructures import MultiDict
 
 from .util import DummyExecutionInfo, TxStatus, custom_int, fixed_length_hex, parse_args
 from .starknet_wrapper import Choice, StarknetWrapper
+from .origin import Origin, NullOrigin
 
 app = Flask(__name__)
 CORS(app)
-
-starknet_wrapper = StarknetWrapper()
 
 @app.route("/is_alive", methods=["GET"])
 @app.route("/gateway/is_alive", methods=["GET"])
@@ -172,13 +171,10 @@ def get_transaction_receipt():
     ret = starknet_wrapper.get_transaction_receipt(transaction_hash)
     return jsonify(ret)
 
-def main():
-    """The main function, used when running this module directly."""
-    # reduce startup logging
-    os.environ['WERKZEUG_RUN_MAIN'] = 'true'
+# reduce startup logging
+os.environ['WERKZEUG_RUN_MAIN'] = 'true'
 
-    args = parse_args()
-    app.run(**vars(args))
-
-if __name__ == "__main__":
-    main()
+args = parse_args()
+origin = Origin(args.fork) if args.fork else NullOrigin()
+starknet_wrapper = StarknetWrapper()
+app.run(**vars(args))

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -15,7 +15,7 @@ from werkzeug.datastructures import MultiDict
 
 from .util import DummyExecutionInfo, TxStatus, custom_int, fixed_length_hex, parse_args
 from .starknet_wrapper import Choice, StarknetWrapper
-from .origin import Origin, NullOrigin
+from .origin import NullOrigin
 
 app = Flask(__name__)
 CORS(app)
@@ -181,7 +181,9 @@ def get_transaction_receipt():
     return jsonify(ret)
 
 args = parse_args()
-origin = Origin(args.fork) if args.fork else NullOrigin()
+# Uncomment this once fork support is added
+# origin = Origin(args.fork) if args.fork else NullOrigin()
+origin = NullOrigin()
 starknet_wrapper = StarknetWrapper(origin)
 
 def main():

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -177,4 +177,4 @@ os.environ['WERKZEUG_RUN_MAIN'] = 'true'
 args = parse_args()
 origin = Origin(args.fork) if args.fork else NullOrigin()
 starknet_wrapper = StarknetWrapper(origin)
-app.run(**vars(args))
+app.run(host=args.host, port=args.port)

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -110,11 +110,20 @@ def _check_block_hash(request_args: MultiDict):
 
 @app.route("/feeder_gateway/get_block", methods=["GET"])
 async def get_block():
-    """Endpoint for retrieving blocks identified by their hash or number."""
+    """Endpoint for retrieving a block identified by its hash or number."""
+
     block_hash = request.args.get("blockHash")
     block_number = request.args.get("blockNumber", type=custom_int)
+
+    if block_hash is not None and block_number is not None:
+        message = "Ambiguous criteria: only one of (block number, block hash) can be provided."
+        abort(Response(message, 500))
+
     try:
-        result_dict = starknet_wrapper.get_block(block_hash=block_hash, block_number=block_number)
+        if block_hash is not None:
+            result_dict = starknet_wrapper.get_block_by_hash(block_hash)
+        else:
+            result_dict = starknet_wrapper.get_block_by_number(block_number)
     except StarkException as err:
         abort(Response(err.message, 500))
     return jsonify(result_dict)
@@ -171,10 +180,17 @@ def get_transaction_receipt():
     ret = starknet_wrapper.get_transaction_receipt(transaction_hash)
     return jsonify(ret)
 
-# reduce startup logging
-os.environ['WERKZEUG_RUN_MAIN'] = 'true'
-
 args = parse_args()
 origin = Origin(args.fork) if args.fork else NullOrigin()
 starknet_wrapper = StarknetWrapper(origin)
-app.run(host=args.host, port=args.port)
+
+def main():
+    """Runs the server."""
+
+    # reduce startup logging
+    os.environ['WERKZEUG_RUN_MAIN'] = 'true'
+
+    app.run(host=args.host, port=args.port)
+
+if __name__ == "__main__":
+    main()

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -223,7 +223,7 @@ class StarknetWrapper:
         The `transaction` dict should also contain a key `transaction`.
         """
 
-        block_number = len(self.__own_blocks)
+        block_number = self.get_number_of_blocks()
         block_hash = hex(block_number)
         state_root = await self.__get_state_root()
 
@@ -233,7 +233,7 @@ class StarknetWrapper:
         block = {
             "block_hash": block_hash,
             "block_number": block_number,
-            "parent_block_hash": self.__own_blocks[-1]["block_hash"] if self.__own_blocks else "0x0",
+            "parent_block_hash": self.__get_last_block()["block_hash"] if self.__own_blocks else "0x0",
             "state_root": state_root,
             "status": TxStatus.ACCEPTED_ON_L2.name,
             "timestamp": int(time.time()),
@@ -244,6 +244,10 @@ class StarknetWrapper:
         number_of_blocks = self.get_number_of_blocks()
         self.__own_blocks[number_of_blocks] = block
         self.__hash2block[int(block_hash, 16)] = block
+
+    def __get_last_block(self):
+        number_of_blocks = self.get_number_of_blocks()
+        return self.get_block_by_number(number_of_blocks - 1)
 
     def get_block_by_hash(self, block_hash: str):
         """Returns the block identified either by its `block_hash`"""
@@ -257,7 +261,7 @@ class StarknetWrapper:
         """Returns the block whose block_number is provided"""
         if block_number is None:
             if self.__own_blocks:
-                return self.__own_blocks[-1]
+                return self.__get_last_block()
             return self.origin.get_block_by_number(block_number)
 
         if block_number < 0:

--- a/starknet_devnet/transaction_wrapper.py
+++ b/starknet_devnet/transaction_wrapper.py
@@ -1,0 +1,12 @@
+"""
+Contains code for wrapping transactions.
+"""
+
+from dataclasses import dataclass
+
+@dataclass
+class TransactionWrapper:
+    """Wraps a transaction and its receipt."""
+    def __init__(self, transaction, receipt):
+        self.transaction = transaction
+        self.receipt = receipt

--- a/starknet_devnet/util.py
+++ b/starknet_devnet/util.py
@@ -51,7 +51,6 @@ def fixed_length_hex(arg: int) -> str:
     """
     Converts the int input to a hex output of fixed length
     """
-
     return f"0x{arg:064x}"
 
 def fork_url(name: str):

--- a/starknet_devnet/util.py
+++ b/starknet_devnet/util.py
@@ -53,17 +53,18 @@ def fixed_length_hex(arg: int) -> str:
     """
     return f"0x{arg:064x}"
 
-def fork_url(name: str):
-    """
-    Return the URL corresponding to the provided name.
-    If it's not one of predefined names, assumes it is already a URL.
-    """
-    if name in ["alpha", "alpha-goerli"]:
-        return "https://alpha4.starknet.io"
-    if name == "alpha-mainnet":
-        return "https://alpha-mainnet.starknet.io"
-    # otherwise a URL; perhaps check validity
-    return name
+# Uncomment this once fork support is added
+# def _fork_url(name: str):
+#     """
+#     Return the URL corresponding to the provided name.
+#     If it's not one of predefined names, assumes it is already a URL.
+#     """
+#     if name in ["alpha", "alpha-goerli"]:
+#         return "https://alpha4.starknet.io"
+#     if name == "alpha-mainnet":
+#         return "https://alpha-mainnet.starknet.io"
+#     # otherwise a URL; perhaps check validity
+#     return name
 
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 5000
@@ -90,12 +91,13 @@ def parse_args():
         help=f"Specify the port to listen at; defaults to {DEFAULT_PORT}",
         default=DEFAULT_PORT
     )
-    parser.add_argument(
-        "--fork", "-f",
-        type=fork_url,
-        help="Specify the network to fork: can be a URL (e.g. https://alpha-mainnet.starknet.io) " +
-             "or network name (alpha or alpha-mainnet)",
-    )
+    # Uncomment this once fork support is added
+    # parser.add_argument(
+    #     "--fork", "-f",
+    #     type=_fork_url,
+    #     help="Specify the network to fork: can be a URL (e.g. https://alpha-mainnet.starknet.io) " +
+    #          "or network name (alpha or alpha-mainnet)",
+    # )
 
     return parser.parse_args()
 

--- a/starknet_devnet/util.py
+++ b/starknet_devnet/util.py
@@ -54,6 +54,18 @@ def fixed_length_hex(arg: int) -> str:
 
     return f"0x{arg:064x}"
 
+def fork_url(name: str):
+    """
+    Return the URL corresponding to the provided name.
+    If it's not one of predefined names, assumes it is already a URL.
+    """
+    if name in ["alpha", "alpha-goerli"]:
+        return "https://alpha4.starknet.io"
+    if name == "alpha-mainnet":
+        return "https://alpha-mainnet.starknet.io"
+    # otherwise a URL; perhaps check validity
+    return name
+
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 5000
 def parse_args():
@@ -69,7 +81,8 @@ def parse_args():
     )
     parser.add_argument(
         "--host",
-        help=f"Specify the address to listen at; defaults to {DEFAULT_HOST} (use the address the program outputs on start)",
+        help=f"Specify the address to listen at; defaults to {DEFAULT_HOST}" +
+             "(use the address the program outputs on start)",
         default=DEFAULT_HOST
     )
     parser.add_argument(
@@ -77,6 +90,12 @@ def parse_args():
         type=int,
         help=f"Specify the port to listen at; defaults to {DEFAULT_PORT}",
         default=DEFAULT_PORT
+    )
+    parser.add_argument(
+        "--fork", "-f",
+        type=fork_url,
+        help="Specify the network to fork: can be a URL (e.g. https://alpha-mainnet.starknet.io) " +
+             "or network name (alpha or alpha-mainnet)",
     )
 
     return parser.parse_args()


### PR DESCRIPTION
## Usage
- This PR introduces no changes to the way users will use Devnet.

## Dev
- Introduce the `Origin` class and its children:
  - Have Devnet use an origin (the parent chain)
  - `NullOrigin` indicates no forking is actually done (will be the default)
  - `ForkOrigin` is not yet implemented, but should allow communicating with the parent chain once it's decided how exactly it should be done.
- Add the `TransactionWrapper` class to wrap transaction itself and its receipt.
- Split `StarknetWrapper`'s `get_block` into two functions: `get_block_by_number` and `get_block_by_hash`.

## Important notes
- Even though the name of the branch being merged is `fork`, it does not yet introduce the forking functionality. 
- Initially there was also CLI support (the `--fork` option), but now it's commented out not to give users false hope by appearing when typing `starknet-devnet --help`.