### PR TITLE
Add linting to CI; fix Readme support list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,9 @@ jobs:
           name: Install dependencies
           command: poetry install
       - run:
+          name: Lint
+          command: poetry run pylint starknet_devnet
+      - run:
           name: Setup example
           command: ./scripts/setup_example.sh
       - run:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ If you don't specify the `HOST` part, the server will indeed be available on all
     - returns complete data for invoke transactions
     - returns partial data for deploy transactions
 - The following Starknet CLI commands are **not** supported:
-  - `get_block` - transactions are not organized into blocks
   - `get_contract_addresses` - L1-L2 interaction is currently not supported
 
 ## Hardhat integration


### PR DESCRIPTION
## Usage
- Fix the fact that `get_block` was a part of both supported and unsupported commands.

## Dev
- https://github.com/Shard-Labs/starknet-devnet/pull/21 was supposed to also add linting to the CI steps; turns out it didn't.

@dribeiro-ShardLabs, once this is merged, rebase the branch in #24.