### PR TITLE
Refactor StarknetWrapper and TransactionWrapper

### DIFF
--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -44,10 +44,8 @@ async def add_transaction():
     if tx_type == TransactionType.DEPLOY.name:
         contract_address, transaction_hash = await starknet_wrapper.deploy(transaction)
         result_dict = {}
-
     elif tx_type == TransactionType.INVOKE_FUNCTION.name:
         contract_address, transaction_hash, result_dict = await starknet_wrapper.invoke(transaction)
-
     else:
         abort(Response(f"Invalid tx_type: {tx_type}.", 400))
 

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -187,7 +187,6 @@ class StarknetWrapper:
 
         tx_hash_int = int(transaction_hash,16)
         if tx_hash_int in self.__transaction_wrappers:
-
             return self.__transaction_wrappers[tx_hash_int].receipt
 
         return {
@@ -203,6 +202,7 @@ class StarknetWrapper:
     async def __generate_block(self, transaction: dict, receipt: dict):
         """
         Generates a block and stores it to blocks and hash2block. The block contains just the passed transaction.
+        Also modifies the `transaction` and `receipt` objects received.
         The `transaction` dict should also contain a key `transaction`.
         """
 
@@ -280,9 +280,11 @@ class StarknetWrapper:
         starknet = await self.get_starknet()
 
         if transaction.tx_type == TransactionType.DEPLOY:
-            tx_wrapper = DeployTransactionWrapper(transaction,status,starknet)
+            tx_wrapper = DeployTransactionWrapper(transaction, status, starknet)
+        elif transaction.tx_type == TransactionType.INVOKE_FUNCTION:
+            tx_wrapper = InvokeTransactionWrapper(transaction, status, starknet)
         else:
-            tx_wrapper = InvokeTransactionWrapper(transaction,status,starknet)
+            raise StarknetDevnetException(message=f"Illegal tx_type: {transaction.tx_type}")
 
         tx_wrapper.generate_receipt(execution_info)
 

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -175,9 +175,8 @@ class StarknetWrapper:
     def get_transaction_status(self, transaction_hash: str):
         """Returns the status of the transaction identified by `transaction_hash`."""
 
-        tx_hash_int = int(transaction_hash,16)
+        tx_hash_int = int(transaction_hash, 16)
         if tx_hash_int in self.__transaction_wrappers:
-
             transaction_wrapper = self.__transaction_wrappers[tx_hash_int]
 
             transaction = transaction_wrapper.transaction
@@ -202,7 +201,6 @@ class StarknetWrapper:
 
         tx_hash_int = int(transaction_hash,16)
         if tx_hash_int in self.__transaction_wrappers:
-
             return self.__transaction_wrappers[tx_hash_int].transaction
 
         return self.origin.get_transaction(transaction_hash)

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -298,7 +298,8 @@ class StarknetWrapper:
             assert error_message, "error_message must be present if tx rejected"
             tx_wrapper.set_failure_reason(error_message)
         else:
-            await self.__generate_block(tx_wrapper.transaction, tx_wrapper.receipt)
+            block_hash, block_number = await self.__generate_block(tx_wrapper.transaction, tx_wrapper.receipt)
+            tx_wrapper.set_block_data(block_hash, block_number)
 
         numeric_hash = int(tx_wrapper.transaction_hash, 16)
         self.__transaction_wrappers[numeric_hash] = tx_wrapper

--- a/starknet_devnet/transaction_wrapper.py
+++ b/starknet_devnet/transaction_wrapper.py
@@ -87,7 +87,7 @@ class DeployTransactionWrapper(TransactionWrapper):
             status,
             execution_info,
             DeployTransactionDetails(
-                TransactionType.DEPLOY,
+                TransactionType.DEPLOY.name,
                 contract_address=fixed_length_hex(internal_tx.contract_address),
                 transaction_hash=fixed_length_hex(internal_tx.hash_value),
                 constructor_calldata=[str(arg) for arg in internal_tx.constructor_calldata],
@@ -104,7 +104,7 @@ class InvokeTransactionWrapper(TransactionWrapper):
             status,
             execution_info,
             InvokeTransactionDetails(
-                TransactionType.INVOKE_FUNCTION,
+                TransactionType.INVOKE_FUNCTION.name,
                 contract_address=fixed_length_hex(internal_tx.contract_address),
                 transaction_hash=fixed_length_hex(internal_tx.hash_value),
                 calldata=[str(arg) for arg in internal_tx.calldata],

--- a/starknet_devnet/transaction_wrapper.py
+++ b/starknet_devnet/transaction_wrapper.py
@@ -61,7 +61,7 @@ class TransactionWrapper(ABC):
             "transaction_index": 0 # always the first (and only) tx in the block
         }
 
-    def set_block_data(self, block_number: int, block_hash: str):
+    def set_block_data(self, block_hash: str, block_number: int):
         """Sets `block_hash` and `block_number` to the wrapped transaction and receipt."""
         self.transaction["block_hash"] = self.receipt["block_hash"] = block_hash
         self.transaction["block_number"] = self.receipt["block_number"] = block_number


### PR DESCRIPTION
## Usage
- No change in the way users will see Devnet (actually depends on how we look at the state update not being run after unsuccessful deployments).

## Dev
- `StarknetWrapper`:
  - `__update_state` was called in StarknetWrapper.deploy regardless of deployment success - this was probably wrong.
  - Separate `call` and `invoke`.
  - Make invoke transactions follow the same principle so far used by deploy transactions (push try-except logic from `server` to `StarknetWrapper`).
- `TransactionWrapper`:
  - Tx hash is taken from internal tx objects (tx wrappers no longer require Starknet state/config)
  - Make more use of super constructor.
  - Eliminate `generate_transaction`.
  - Use helper classes (Details classes) instead of `**kwargs`.