### PR TITLE
Update cairo-lang to 0.7.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -129,7 +129,7 @@ python-versions = "~=3.5"
 
 [[package]]
 name = "cairo-lang"
-version = "0.6.2"
+version = "0.7.0"
 description = "Compiler and runner for the Cairo language"
 category = "main"
 optional = false
@@ -1116,7 +1116,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "87ebb4f0be23da31c78631efdaa5906590dc5212f70cab3468a31210fbd6f34c"
+content-hash = "2ac4ab70666f6407a977e8291f7f2eb0c9038c48cf3189d74a6ba28676a03421"
 
 [metadata.files]
 aiohttp = [
@@ -1233,7 +1233,7 @@ cachetools = [
     {file = "cachetools-4.2.4.tar.gz", hash = "sha256:89ea6f1b638d5a73a4f9226be57ac5e4f399d22770b92355f92dcb0f7f001693"},
 ]
 cairo-lang = [
-    {file = "cairo-lang-0.6.2.zip", hash = "sha256:ff3cf5fd4c92e861f22c853ccb22ec384abdcb6c7fa042b93e16d5c6ace6b9a4"},
+    {file = "cairo-lang-0.7.0.zip", hash = "sha256:d8271e67ace050d49d4f1e8a4f36f2338948e48ce62975dd11ecfacfeac9e409"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -1466,6 +1466,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
@@ -1477,6 +1480,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1488,6 +1494,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
@@ -1500,6 +1509,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1512,6 +1524,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = ["starknet", "cairo", "testnet", "local", "server"]
 python = "^3.7"
 Flask = {extras = ["async"], version = "^2.0.2"}
 flask-cors = "^3.0.10"
-cairo-lang = "0.6.2"
+cairo-lang = "0.7.0"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.12.2"


### PR DESCRIPTION
Noticed cairo was locked to 0.6.2 and bumped it up to the latest 0.7.0

I assume it was a deliberate choice to lock to a single version rather than allow updates? With that in mind, I opted to keep it locked at 0.7.0 instead of a caret or tilde requirement

If you'd rather not get community contribs for maintenance things like this (doing it on your own schedule or smthn) feel free to close :) (edit: or if its significantly more involved of an update, no worries)

## Testing
`./scripts/test_cli.sh`

```
(starknet-devnet-CtidCXsa-py3.7) sam@sam:~/dev/eth/starknet/starknet-devnet$ ./scripts/test_cli.sh
 * Running on http://localhost:5000/ (Press CTRL+C to quit)
127.0.0.1 - - [18/Jan/2022 16:49:29] "POST /gateway/add_transaction HTTP/1.1" 200 -
Address: 0x01526fa236d66b986fad9e4ff41381749ce0551ef60dc23ddd605168ee89382f
tx_hash: 0x070ba10ed783514153f224d2998646b20674e86cbf78882264257f5bfbbfd38d
127.0.0.1 - - [18/Jan/2022 16:49:31] "GET /feeder_gateway/get_transaction_status?transactionHash=0x070ba10ed783514153f224d2998646b20674e86cbf78882264257f5bfbbfd38d HTTP/1.1" 200 -
127.0.0.1 - - [18/Jan/2022 16:49:33] "GET /feeder_gateway/get_transaction?transactionHash=0x070ba10ed783514153f224d2998646b20674e86cbf78882264257f5bfbbfd38d HTTP/1.1" 200 -
127.0.0.1 - - [18/Jan/2022 16:49:35] "GET /feeder_gateway/get_storage_at?contractAddress=0x1526fa236d66b986fad9e4ff41381749ce0551ef60dc23ddd605168ee89382f&key=916907772491729262376534102982219947830828984996257231353398618781993312401&blockNumber=null HTTP/1.1" 200 -
Got storage successfully: 0x0
127.0.0.1 - - [18/Jan/2022 16:49:36] "GET /feeder_gateway/get_block?blockNumber=-1 HTTP/1.1" 500 -
Error: BadRequest: HTTP error ocurred. Status: 500. Text: Block number must be a non-negative integer; got: -1.
Correctly rejecting negative input
127.0.0.1 - - [18/Jan/2022 16:49:38] "GET /feeder_gateway/get_block?blockNumber=1000 HTTP/1.1" 500 -
127.0.0.1 - - [18/Jan/2022 16:49:39] "GET /feeder_gateway/get_block?blockNumber=null HTTP/1.1" 200 -
127.0.0.1 - - [18/Jan/2022 16:49:41] "GET /feeder_gateway/get_block?blockNumber=0 HTTP/1.1" 200 -
127.0.0.1 - - [18/Jan/2022 16:49:43] "GET /feeder_gateway/get_transaction_receipt?transactionHash=0x070ba10ed783514153f224d2998646b20674e86cbf78882264257f5bfbbfd38d HTTP/1.1" 200 -
Correct block_number
Correct transaction_hash
Correct transaction_index
127.0.0.1 - - [18/Jan/2022 16:49:44] "GET /feeder_gateway/get_code?contractAddress=0x1526fa236d66b986fad9e4ff41381749ce0551ef60dc23ddd605168ee89382f&blockNumber=null HTTP/1.1" 200 -
127.0.0.1 - - [18/Jan/2022 16:49:46] "POST /gateway/add_transaction HTTP/1.1" 200 -
127.0.0.1 - - [18/Jan/2022 16:49:49] "POST /feeder_gateway/call_contract?blockNumber=null HTTP/1.1" 200 -

Invoke successful!
127.0.0.1 - - [18/Jan/2022 16:49:50] "GET /feeder_gateway/get_storage_at?contractAddress=0x1526fa236d66b986fad9e4ff41381749ce0551ef60dc23ddd605168ee89382f&key=916907772491729262376534102982219947830828984996257231353398618781993312401&blockNumber=null HTTP/1.1" 200 -
Got storage successfully: 0x1e
127.0.0.1 - - [18/Jan/2022 16:49:52] "GET /feeder_gateway/get_block?blockNumber=-1 HTTP/1.1" 500 -
Error: BadRequest: HTTP error ocurred. Status: 500. Text: Block number must be a non-negative integer; got: -1.
Correctly rejecting negative input
127.0.0.1 - - [18/Jan/2022 16:49:54] "GET /feeder_gateway/get_block?blockNumber=1000 HTTP/1.1" 500 -
127.0.0.1 - - [18/Jan/2022 16:49:55] "GET /feeder_gateway/get_block?blockNumber=null HTTP/1.1" 200 -
127.0.0.1 - - [18/Jan/2022 16:49:57] "GET /feeder_gateway/get_block?blockNumber=1 HTTP/1.1" 200 -
127.0.0.1 - - [18/Jan/2022 16:49:59] "GET /feeder_gateway/get_transaction_receipt?transactionHash=0x06d64b9bad90996eb8c84bc666bbf77abed827f458f7a90626014ac16ebeda5e HTTP/1.1" 200 -
Correct block_number
Correct transaction_hash
Correct transaction_index
Deploying with salt 1)
127.0.0.1 - - [18/Jan/2022 16:50:18] "POST /gateway/add_transaction HTTP/1.1" 200 -
127.0.0.1 - - [18/Jan/2022 16:50:20] "GET /feeder_gateway/get_transaction_status?transactionHash=0x02d3c5827c7067c485e14943c8893f52873680d72f88396a5d02ddb743dc4598 HTTP/1.1" 200 -
Deploying with salt 2)
127.0.0.1 - - [18/Jan/2022 16:50:31] "POST /gateway/add_transaction HTTP/1.1" 200 -
127.0.0.1 - - [18/Jan/2022 16:50:33] "GET /feeder_gateway/get_transaction_status?transactionHash=0x02d3c5827c7067c485e14943c8893f52873680d72f88396a5d02ddb743dc4598 HTTP/1.1" 200 -
127.0.0.1 - - [18/Jan/2022 16:50:38] "POST /gateway/add_transaction HTTP/1.1" 200 -
127.0.0.1 - - [18/Jan/2022 16:50:40] "GET /feeder_gateway/get_transaction_status?transactionHash=0x048f60251353141d8c12cd4d9f3574b847370cb3852c35ff29966e230d6edb90 HTTP/1.1" 200 -
```