### PR TITLE
Get full contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ If you don't specify the `HOST` part, the server will indeed be available on all
   - `invoke`
   - `tx_status`
   - `get_transaction_receipt`
+  - `get_full_contract`
 - The following Starknet CLI commands are **not** supported:
   - `get_contract_addresses`
   - `get_state_update`
-  - `get_full_contract`
 
 ## Hardhat integration
 - If you're using [the Hardhat plugin](https://github.com/Shard-Labs/starknet-hardhat-plugin), see [here](https://github.com/Shard-Labs/starknet-hardhat-plugin#testing-network) on how to edit its config file to integrate Devnet.

--- a/starknet_devnet/contract_wrapper.py
+++ b/starknet_devnet/contract_wrapper.py
@@ -29,6 +29,8 @@ class ContractWrapper:
     """
     def __init__(self, contract: StarknetContract, contract_definition: ContractDefinition):
         self.contract: StarknetContract = contract
+        self.contract_definition = contract_definition;
+
         self.code: dict = {
             "abi": contract_definition.abi,
             "bytecode": [hex(el) for el in contract_definition.program.data]

--- a/starknet_devnet/contract_wrapper.py
+++ b/starknet_devnet/contract_wrapper.py
@@ -29,7 +29,7 @@ class ContractWrapper:
     """
     def __init__(self, contract: StarknetContract, contract_definition: ContractDefinition):
         self.contract: StarknetContract = contract
-        self.contract_definition = contract_definition.dump();
+        self.contract_definition = contract_definition.dump()
 
         self.code: dict = {
             "abi": contract_definition.abi,

--- a/starknet_devnet/contract_wrapper.py
+++ b/starknet_devnet/contract_wrapper.py
@@ -29,11 +29,11 @@ class ContractWrapper:
     """
     def __init__(self, contract: StarknetContract, contract_definition: ContractDefinition):
         self.contract: StarknetContract = contract
-        self.contract_definition = contract_definition;
+        self.contract_definition = contract_definition.dump();
 
         self.code: dict = {
             "abi": contract_definition.abi,
-            "bytecode": [hex(el) for el in contract_definition.program.data]
+            "bytecode": self.contract_definition["program"]["data"]
         }
 
         self.types: dict = extract_types(contract_definition.abi)

--- a/starknet_devnet/contract_wrapper.py
+++ b/starknet_devnet/contract_wrapper.py
@@ -29,7 +29,7 @@ class ContractWrapper:
     """
     def __init__(self, contract: StarknetContract, contract_definition: ContractDefinition):
         self.contract: StarknetContract = contract
-        self.contract_definition = contract_definition.dump()
+        self.contract_definition = contract_definition.remove_debug_info().dump()
 
         self.code: dict = {
             "abi": contract_definition.abi,

--- a/starknet_devnet/origin.py
+++ b/starknet_devnet/origin.py
@@ -83,6 +83,13 @@ class NullOrigin(Origin):
             "bytecode": []
         }
 
+    def get_full_contract(self, contract_address: int) -> dict:
+        return {
+            "abi": {},
+            "entry_points_by_type": {},
+            "program": {}
+        }
+
     def get_storage_at(self, contract_address: int, key: int) -> str:
         return hex(0)
 
@@ -112,6 +119,9 @@ class ForkedOrigin(Origin):
         raise NotImplementedError
 
     def get_code(self, contract_address: int) -> dict:
+        raise NotImplementedError
+
+    def get_full_contract(self, contract_address: int) -> dict:
         raise NotImplementedError
 
     def get_storage_at(self, contract_address: int, key: int) -> str:

--- a/starknet_devnet/origin.py
+++ b/starknet_devnet/origin.py
@@ -3,6 +3,7 @@ Contains classes that provide the abstraction of L2 blockchain.
 """
 
 from starknet_devnet.util import StarknetDevnetException, TxStatus
+from starkware.starknet.services.api.contract_definition import ContractDefinition
 
 
 class Origin:
@@ -32,6 +33,10 @@ class Origin:
 
     def get_code(self, contract_address: int) -> dict:
         """Returns the code of the contract."""
+        raise NotImplementedError
+
+    def get_full_contract(self, contract_address: int) -> ContractDefinition:
+        """Returns the contract definition"""
         raise NotImplementedError
 
     def get_storage_at(self, contract_address: int, key: int) -> str:

--- a/starknet_devnet/origin.py
+++ b/starknet_devnet/origin.py
@@ -3,8 +3,6 @@ Contains classes that provide the abstraction of L2 blockchain.
 """
 
 from starknet_devnet.util import StarknetDevnetException, TxStatus
-from starkware.starknet.services.api.contract_definition import ContractDefinition
-
 
 class Origin:
     """
@@ -35,7 +33,7 @@ class Origin:
         """Returns the code of the contract."""
         raise NotImplementedError
 
-    def get_full_contract(self, contract_address: int) -> ContractDefinition:
+    def get_full_contract(self, contract_address: int) -> dict:
         """Returns the contract definition"""
         raise NotImplementedError
 

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -136,6 +136,17 @@ def get_code():
     result_dict = starknet_wrapper.get_code(contract_address)
     return jsonify(result_dict)
 
+@app.route("/feeder_gateway/get_full_contract", methods=["GET"])
+def get_full_contract():
+    """
+    Returns the contract definition of the contract whose contractAddress is provided.
+    """
+    _check_block_hash(request.args)
+
+    contract_address = request.args.get("contractAddress", type=custom_int)
+    result_dict = starknet_wrapper.get_full_contract(contract_address)
+    return jsonify(result_dict)
+
 @app.route("/feeder_gateway/get_storage_at", methods=["GET"])
 async def get_storage_at():
     """Endpoint for returning the storage identified by `key` from the contract at """

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -147,10 +147,10 @@ def get_full_contract():
 
     try:
         result_dict = starknet_wrapper.get_full_contract(contract_address)
-        return jsonify(result_dict)
     except StarknetDevnetException as error:
         # alpha throws 500 for unitialized contracts
         abort(Response(error.message, 500))
+    return jsonify(result_dict)
 
 @app.route("/feeder_gateway/get_storage_at", methods=["GET"])
 async def get_storage_at():

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -17,6 +17,7 @@ from starkware.starknet.testing.starknet import Starknet
 from starkware.starknet.testing.objects import StarknetTransactionExecutionInfo
 from starkware.starkware_utils.error_handling import StarkException
 from starkware.starknet.services.api.feeder_gateway.block_hash import calculate_block_hash
+from starkware.starknet.services.api.contract_definition import ContractDefinition
 
 from .origin import NullOrigin, Origin
 from .util import Choice, StarknetDevnetException, TxStatus, fixed_length_hex, DummyExecutionInfo, enable_pickling
@@ -370,6 +371,13 @@ class StarknetWrapper:
             contract_wrapper = self.__get_contract_wrapper(contract_address)
             return contract_wrapper.code
         return self.__origin.get_code(contract_address)
+
+    def get_full_contract(self, contract_address: int) -> ContractDefinition:
+        """Returns a `ContractDefinition` of the contract at `contract_address`."""
+        if self.__is_contract_deployed(contract_address):
+            contract_wrapper = self.__get_contract_wrapper(contract_address)
+            return contract_wrapper.contract_definition
+        return self.__origin.get_full_contract(contract_address)
 
     async def get_storage_at(self, contract_address: int, key: int) -> str:
         """

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -373,10 +373,8 @@ class StarknetWrapper:
 
     def get_full_contract(self, contract_address: int) -> dict:
         """Returns a `dict` contract definition of the contract at `contract_address`."""
-        if self.__is_contract_deployed(contract_address):
-            contract_wrapper = self.__get_contract_wrapper(contract_address)
-            return contract_wrapper.contract_definition
-        return self.__origin.get_full_contract(contract_address)
+        contract_wrapper = self.__get_contract_wrapper(contract_address)
+        return contract_wrapper.contract_definition
 
     async def get_storage_at(self, contract_address: int, key: int) -> str:
         """

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -17,7 +17,6 @@ from starkware.starknet.testing.starknet import Starknet
 from starkware.starknet.testing.objects import StarknetTransactionExecutionInfo
 from starkware.starkware_utils.error_handling import StarkException
 from starkware.starknet.services.api.feeder_gateway.block_hash import calculate_block_hash
-from starkware.starknet.services.api.contract_definition import ContractDefinition
 
 from .origin import NullOrigin, Origin
 from .util import Choice, StarknetDevnetException, TxStatus, fixed_length_hex, DummyExecutionInfo, enable_pickling
@@ -372,8 +371,8 @@ class StarknetWrapper:
             return contract_wrapper.code
         return self.__origin.get_code(contract_address)
 
-    def get_full_contract(self, contract_address: int) -> ContractDefinition:
-        """Returns a `ContractDefinition` of the contract at `contract_address`."""
+    def get_full_contract(self, contract_address: int) -> dict:
+        """Returns a `dict` contract definition of the contract at `contract_address`."""
         if self.__is_contract_deployed(contract_address):
             contract_wrapper = self.__get_contract_wrapper(contract_address)
             return contract_wrapper.contract_definition

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -46,7 +46,7 @@ assert_transaction_receipt_not_received(NONEXISTENT_TX_HASH)
 assert_contract_code(deploy_info["address"])
 
 # check contract definition
-assert_contract_definition(deploy_info["address"])
+assert_contract_definition(deploy_info["address"], CONTRACT_PATH)
 
 # increase and assert balance
 invoke_tx_hash = invoke(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3,6 +3,7 @@ The main testing script. Runs the devnet and calls its endpoints.
 """
 
 from .util import (
+    assert_contract_definition,
     assert_negative_block_input,
     assert_transaction_not_received,
     assert_transaction_receipt_not_received,
@@ -43,6 +44,9 @@ assert_transaction_receipt_not_received(NONEXISTENT_TX_HASH)
 
 # check code
 assert_contract_code(deploy_info["address"])
+
+# check contract definition
+assert_contract_definition(deploy_info["address"])
 
 # increase and assert balance
 invoke_tx_hash = invoke(

--- a/test/util.py
+++ b/test/util.py
@@ -177,11 +177,10 @@ def assert_contract_definition(address, contract_path):
     ])
     contract_definition: ContractDefinition = ContractDefinition.load(json.loads(output.stdout))
 
-    with open(contract_path, encoding="utf-8") as contract_file:
-        loaded_contract = json.load(contract_file)
-        loaded_contract_definition: ContractDefinition = ContractDefinition.Schema().load(loaded_contract)
+    loaded_contract = load_json_from_path(contract_path)
+    loaded_contract_definition: ContractDefinition = ContractDefinition.load(loaded_contract)
 
-        assert_equal(contract_definition, loaded_contract_definition.remove_debug_info())
+    assert_equal(contract_definition, loaded_contract_definition.remove_debug_info())
 
 def assert_storage(address, key, expected_value):
     """Asserts the storage value stored at (address, key)."""

--- a/test/util.py
+++ b/test/util.py
@@ -167,6 +167,16 @@ def assert_contract_code(address):
     # just checking key equality
     assert_equal(sorted(code.keys()), ["abi", "bytecode"])
 
+def assert_contract_definition(address):
+    """Asserts the content of the contract definition of a contract at address."""
+    output = my_run([
+        "starknet", "get_full_contract",
+        "--contract_address", address
+    ])
+    contract_definition = json.loads(output.stdout)
+    # just checking key equality
+    assert_equal(sorted(contract_definition.keys()), ["abi", "entry_points_by_type", "program"])
+
 def assert_storage(address, key, expected_value):
     """Asserts the storage value stored at (address, key)."""
     output = my_run([


### PR DESCRIPTION
## Usage
* Introduced support for the `get_full_contract` CLI command for fetching the contract definition from the provided contract address 