### PR TITLE
Fix test splitting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,10 @@ jobs:
           name: Run pytest tests
           parallel: true
           command: |
-            TESTFILES=$(circleci tests glob test/test*.py | circleci tests split --split-by=timings --timings-type=classname)
+            TESTFILES=$(
+                circleci tests glob test/test*.py |
+                circleci tests split --split-by=timings --timings-type=classname
+            )
             mkdir -p test-results
             poetry run pytest -s --junitxml=test-results/junit.xml -vv $TESTFILES
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           name: Run pytest tests
           parallel: true
           command: |
-            TESTFILES=$(circleci tests glob test/test*.py | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests glob test/test*.py | circleci tests split --split-by=timings --timings-type=classname)
             mkdir -p test-results
             poetry run pytest -s --junitxml=test-results/junit.xml -vv $TESTFILES
       - store_test_results:


### PR DESCRIPTION
## Usage related changes

None

## Development related changes

- Tests are not being split properly because of the introduction of decorator, so now trying to split according to class name.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the base branch
- [x] Documented the changes
- [x] Updated the tests
