### PR TITLE
Skip address precalculation on successful deployment

### DIFF
--- a/test/test_general_workflow.py
+++ b/test/test_general_workflow.py
@@ -86,6 +86,16 @@ def test_general_workflow():
         contract_path=EVENTS_CONTRACT_PATH,
         salt="0x99",
         inputs=None,
+        expected_status="ACCEPTED_ON_L2",
+        expected_address=EXPECTED_SALTY_DEPLOY_ADDRESS,
+        expected_tx_hash=EXPECTED_SALTY_DEPLOY_HASH
+    )
+
+    assert_salty_deploy(
+        contract_path=EVENTS_CONTRACT_PATH,
+        salt="0x99",
+        inputs=None,
+        expected_status="REJECTED",
         expected_address=EXPECTED_SALTY_DEPLOY_ADDRESS,
         expected_tx_hash=EXPECTED_SALTY_DEPLOY_HASH
     )

--- a/test/util.py
+++ b/test/util.py
@@ -303,14 +303,13 @@ def assert_block_hash(latest_block_number, expected_block_hash):
     assert_equal(block["block_hash"], expected_block_hash)
     assert_equal(block["status"], "ACCEPTED_ON_L2")
 
-def assert_salty_deploy(contract_path, inputs, salt, expected_address, expected_tx_hash):
-    """Run twice deployment with salt. Expect the same output."""
-    for i in range(2):
-        print(f"Running deployment {i + 1})")
-        deploy_info = deploy(contract_path, inputs, salt=salt)
-        assert_tx_status(deploy_info["tx_hash"], "ACCEPTED_ON_L2")
-        assert_equal(deploy_info["address"], expected_address)
-        assert_equal(deploy_info["tx_hash"], expected_tx_hash)
+def assert_salty_deploy(contract_path, inputs, salt, expected_status, expected_address, expected_tx_hash):
+    """Deploy with salt and assert."""
+
+    deploy_info = deploy(contract_path, inputs, salt=salt)
+    assert_tx_status(deploy_info["tx_hash"], expected_status)
+    assert_equal(deploy_info["address"], expected_address)
+    assert_equal(deploy_info["tx_hash"], expected_tx_hash)
 
 def assert_failing_deploy(contract_path):
     """Run deployment for a contract that's expected to be rejected."""


### PR DESCRIPTION
## Usage related changes

- Skip address precalculation on successful deployment.
- Reject second deployment of one contract with the same salt.

## Development related changes

- Adapt the second salty test to reject instead of ignoring.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the base branch
- [x] Documented the changes
- [x] Updated the tests
