### PR TITLE
Fix failure reason in transaction and tx_status

### DIFF
--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -127,7 +127,7 @@ class StarknetWrapper:
         Generates a new block
         """
 
-        if tx_wrapper.transaction["status"] == TxStatus.REJECTED:
+        if tx_wrapper.transaction["status"] == TxStatus.REJECTED.name:
             assert error_message, "error_message must be present if tx rejected"
             tx_wrapper.set_failure_reason(error_message)
         else:


### PR DESCRIPTION
## Usage related changes

- Include failure reason to tx_status and get_transaction response.
- It was impossible to run `starknet get_transaction` for failed transactions on devnet (validation failing on clientside as the response lacked the failure reason).

## Development related changes

- Compare with enum value by its name, not the object itself (`TxStatus.REJECTED.name`)
- The tests did not cover this use case. Now they are improved and should do so.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the base branch
- [x] Documented the changes
- [x] Updated the tests
