### PR TITLE
Fix --lite-mode-block-hash behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,9 +251,9 @@ Consider passing these CLI flags on Devnet startup:
 - `--lite-mode` enables all of the optimizations described below (same as using all of the flags below)
 - `--lite-mode-deploy-hash`
   - disables the calculation of transaction hash for deploy transactions
-  - disables get_state_update functionality
 - `--lite-mode-block-hash`
   - disables the calculation of block hash
+  - disables get_state_update functionality
 
 ## Restart
 

--- a/README.md
+++ b/README.md
@@ -249,8 +249,11 @@ To improve Devnet performance, instead of calculating the actual hash of deploym
 Consider passing these CLI flags on Devnet startup:
 
 - `--lite-mode` enables all of the optimizations described below (same as using all of the flags below)
-- `--lite-mode-deploy-hash` disables the calculation of transaction hash for deploy transactions
-- `--lite-mode-block-hash` disables the calculation of block hash
+- `--lite-mode-deploy-hash`
+  - disables the calculation of transaction hash for deploy transactions
+  - disables get_state_update functionality
+- `--lite-mode-block-hash`
+  - disables the calculation of block hash
 
 ## Restart
 

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -87,26 +87,27 @@ class StarknetWrapper:
         return starknet.state
 
     async def __update_state(self):
+        previous_state = self.__current_carried_state
+        assert previous_state is not None
+        current_carried_state = (await self.get_state()).state
+        state = await self.get_state()
+
+        current_carried_state.block_info = self.block_info_generator.next_block(
+            block_info=current_carried_state.block_info,
+            general_config=state.general_config
+        )
+
+        updated_shared_state = await current_carried_state.shared_state.apply_state_updates(
+            ffc=current_carried_state.ffc,
+            previous_carried_state=previous_state,
+            current_carried_state=current_carried_state
+        )
+
         if not self.config.lite_mode_block_hash:
-            previous_state = self.__current_carried_state
-            assert previous_state is not None
-            current_carried_state = (await self.get_state()).state
-            state = await self.get_state()
+            state.state.shared_state = updated_shared_state
+            await self.__preserve_current_state(state.state)
 
-            current_carried_state.block_info = self.block_info_generator.next_block(
-                block_info=current_carried_state.block_info,
-                general_config=state.general_config
-            )
-
-            updated_shared_state = await current_carried_state.shared_state.apply_state_updates(
-                ffc=current_carried_state.ffc,
-                previous_carried_state=previous_state,
-                current_carried_state=current_carried_state
-            )
-            self.__starknet.state.state.shared_state = updated_shared_state
-            await self.__preserve_current_state(self.__starknet.state.state)
-
-            return generate_state_update(previous_state, current_carried_state)
+        return generate_state_update(previous_state, current_carried_state)
 
     async def __get_state_root(self):
         state = await self.get_state()

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -97,20 +97,22 @@ class StarknetWrapper:
             general_config=state.general_config
         )
 
-        updated_shared_state = await current_carried_state.shared_state.apply_state_updates(
-            ffc=current_carried_state.ffc,
-            previous_carried_state=previous_state,
-            current_carried_state=current_carried_state
-        )
-
         if not self.config.lite_mode_block_hash:
             # This is the most time-intensive part of the function.
             # With only skipping it in lite-mode, we still get the time benefit.
             # In regular mode it's needed for state update calculation and block state_root calculation.
+            updated_shared_state = await current_carried_state.shared_state.apply_state_updates(
+                ffc=current_carried_state.ffc,
+                previous_carried_state=previous_state,
+                current_carried_state=current_carried_state
+            )
+
             state.state.shared_state = updated_shared_state
             await self.__preserve_current_state(state.state)
 
-        return generate_state_update(previous_state, current_carried_state)
+            return generate_state_update(previous_state, current_carried_state)
+
+        return None
 
     async def __get_state_root(self):
         state = await self.get_state()

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -104,6 +104,9 @@ class StarknetWrapper:
         )
 
         if not self.config.lite_mode_block_hash:
+            # This is the most time-intensive part of the function.
+            # With only skipping it in lite-mode, we still get the time benefit.
+            # In regular mode it's needed for state update calculation and block state_root calculation.
             state.state.shared_state = updated_shared_state
             await self.__preserve_current_state(state.state)
 

--- a/test/test_timestamps.py
+++ b/test/test_timestamps.py
@@ -227,3 +227,18 @@ def test_block_info_generator():
     block_after_set_time = generator.next_block(block_info=block_info, general_config=DEFAULT_GENERAL_CONFIG)
 
     assert block_after_set_time.block_timestamp == 222
+
+@pytest.mark.timestamps
+@devnet_in_background("--lite-mode")
+def test_lite_mode_compatibility():
+    """Tests compatibility with lite mode"""
+
+    deploy_info = deploy_ts_contract()
+
+    set_time(100)
+
+    # deploy another contract to generate a new block
+    deploy_ts_contract()
+
+    time_from_contract = get_ts_from_contract(address=deploy_info["address"])
+    assert time_from_contract == 100


### PR DESCRIPTION
## Usage related changes

- Allow timestamp manipulation in lite-mode
- Document that state updates aren't supported with --lite-mode-block-hash

## Development related changes

- In `__update_state` method, the whole body was executed if not running in lite-mode-block-hash:
  - Now the only part dependent on lite-mode-block-hash is state_preservation
  - Rationale: the preservation part of the method takes around 89% of the whole method execution time
- Add compatibility test of lite-mode and timestamp manipulation

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the base branch
- [x] Documented the changes
- [x] Updated the tests
