### PR TITLE
Bump Python max version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,11 @@ aliases:
         only:
           - master
     requires:
-      - test
+      - test-py-min
+      - test-py-max
 
 jobs:
-  test:
+  test-py-min: &test-template
     docker:
       - image: cimg/python:3.7.12-node
     resource_class: medium
@@ -42,6 +43,12 @@ jobs:
             poetry run pytest -s --junitxml=test-results/junit.xml -vv $TESTFILES
       - store_test_results:
           path: test-results
+
+  test-py-max:
+    <<: *test-template
+    docker:
+      - image: cimg/python:3.9-node
+
   package_build_and_publish:
     docker:
       - image: cimg/python:3.7.12
@@ -49,6 +56,7 @@ jobs:
     steps:
       - checkout
       - run: ./scripts/package_build_and_publish.sh
+
   image_build_and_push:
     docker:
       - image: cimg/base:2021.04
@@ -79,7 +87,8 @@ workflows:
   version: 2
   test_and_publish:
     jobs:
-      - test
+      - test-py-min
+      - test-py-max
       - package_build_and_publish:
           <<: *on_master_after_test
       - image_build_and_push:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install starknet-devnet
 
 ### Requirements
 
-Works with Python versions >=3.7.2 and <=3.9.10.
+Works with Python versions >=3.7.2 and <3.10.
 
 On Ubuntu/Debian, first run:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/Shard-Labs/starknet-devnet"
 keywords = ["starknet", "cairo", "testnet", "local", "server"]
 
 [tool.poetry.dependencies]
-python = "^3.7.2"
+python = ">=3.7.2,<3.10"
 Flask = {extras = ["async"], version = "~2.0.3"}
 flask-cors = "~3.0.10"
 cairo-lang = "0.8.2.1"


### PR DESCRIPTION
I guess upcoming Python 3.9 minor releases will not break anything,
so it should be safe to simply state we do support Python until 3.10.

To be more confident, I updated the CI configuration to test min/max supported
Python versions.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the base branch
- [ ] Documented the changes
- [ ] Updated the tests
