### PR TITLE
Allow redeploying with same salt

### DIFF
--- a/starknet_devnet/contract_wrapper.py
+++ b/starknet_devnet/contract_wrapper.py
@@ -12,9 +12,10 @@ class ContractWrapper:
     """
     Wraps a StarknetContract, storing its types and code for later use.
     """
-    def __init__(self, contract: StarknetContract, contract_class: ContractClass):
+    def __init__(self, contract: StarknetContract, contract_class: ContractClass, deployment_tx_hash: int = None):
         self.contract: StarknetContract = contract
         self.contract_class = contract_class.remove_debug_info()
+        self.deployment_tx_hash = deployment_tx_hash
 
         self.code: dict = {
             "abi": contract_class.abi,

--- a/test/test_general_workflow.py
+++ b/test/test_general_workflow.py
@@ -104,7 +104,7 @@ def test_general_workflow():
         contract_path=EVENTS_CONTRACT_PATH,
         salt="0x99",
         inputs=None,
-        expected_status="REJECTED",
+        expected_status="ACCEPTED_ON_L2",
         expected_address=EXPECTED_SALTY_DEPLOY_ADDRESS,
         expected_tx_hash=EXPECTED_SALTY_DEPLOY_HASH
     )


### PR DESCRIPTION
## Usage related changes

- Allow redeploying with same salt; this was removed with #92, but was previously supported, and is still supported on alpha-goerli.

## Development related changes

- `ContractWrapper` now also stores `deployment_tx_hash` (defaults to `None`)
- The `except` block of `deploy` no longer needs to calculate contract address - it can use it as a property of the previously calculated `internal_tx`.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the base branch
- [x] Documented the changes
- [x] Updated the tests
- [x] All tests are passing
