### PR TITLE
feature: added `/load` endpoint to the REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,12 @@ starknet-devnet --dump-on transaction --dump-path <PATH>
 curl -X POST http://<HOST>:<PORT>/dump -d '{ "path": <PATH> }' -H "Content-Type: application/json"
 ```
 
+- Loading state on request `/load`:
+
+```
+curl -X POST http://<HOST>:<PORT>/load -d '{ "path": <PATH> }' -H "Content-Type: application/json"
+```
+
 ### Loading
 
 To load a preserved Devnet instance, run:

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -32,6 +32,18 @@ def dump():
     state.dumper.dump(dump_path)
     return Response(status=200)
 
+@base.route("/load", methods=["POST"])
+def load():
+    """Loads the starknet_wrapper"""
+
+    request_dict = request.json or {}
+    load_path = request_dict.get("path")
+    if not load_path:
+        raise StarknetDevnetException(message="No path provided.", status_code=400)
+
+    state.load(load_path)
+    return Response(status=200)
+
 def validate_time_value(value: int):
     """Validates the time value"""
     if value is None:

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -16,16 +16,37 @@ from .shared import CONTRACT_PATH, ABI_PATH
 
 DUMP_PATH = "dump.pkl"
 
+class DevnetBackgroundProc:
+    """ Helper for ensuring we always have only 1 active devnet server running in background """
+    def __init__(self):
+        self.proc = None
+
+    def start(self, *args, sleep_seconds=5, stderr=None, stdout=None):
+        """ Starts a new devnet-server instance. Previously active instance will be stopped. """
+        self.stop()
+        self.proc = run_devnet_in_background(*args, sleep_seconds=sleep_seconds, stderr=stderr, stdout=stdout)
+        return self.proc
+
+    def stop(self):
+        """ Stops the currently active devnet-server instance """
+        if self.proc:
+            terminate_and_wait(self.proc)
+            self.proc = None
+
+ACTIVE_DEVNET = DevnetBackgroundProc()
+
 @pytest.fixture(autouse=True)
 def run_before_and_after_test():
     """Cleanup after tests finish."""
 
     # before test
-    # nothing
+    ACTIVE_DEVNET.stop()
 
     yield
 
     # after test
+    ACTIVE_DEVNET.stop()
+
     for path in os.listdir():
         if path.endswith(".pkl"):
             os.remove(path)
@@ -85,38 +106,38 @@ def deploy_empty_contract():
 def test_load_if_no_file():
     """Test loading if dump file not present."""
     assert_no_dump_present(DUMP_PATH)
-    devnet_proc = run_devnet_in_background("--load-path", DUMP_PATH, stderr=subprocess.PIPE)
+    devnet_proc = ACTIVE_DEVNET.start("--load-path", DUMP_PATH, stderr=subprocess.PIPE)
     devnet_proc.wait()
     try:
         assert devnet_proc.returncode != 0
         expected_msg = f"Error: Cannot load from {DUMP_PATH}. Make sure the file exists and contains a Devnet dump.\n"
         assert expected_msg == devnet_proc.stderr.read().decode("utf-8")
     finally:
-        terminate_and_wait(devnet_proc)
+        ACTIVE_DEVNET.stop()
 
 def test_dumping_if_path_not_provided():
     """Assert failure if dumping attempted without a known path."""
-    devnet_proc = run_devnet_in_background()
+    ACTIVE_DEVNET.start()
     try:
         resp = send_dump_request()
         assert resp.status_code == 400
     finally:
-        terminate_and_wait(devnet_proc)
+        ACTIVE_DEVNET.stop()
 
 def test_dumping_if_path_provided_as_cli_option():
     """Test dumping if path provided as CLI option"""
-    devnet_proc = run_devnet_in_background("--dump-path", DUMP_PATH)
+    ACTIVE_DEVNET.start("--dump-path", DUMP_PATH)
     try:
         resp = send_dump_request()
         assert resp.status_code == 200
         assert_dump_present(DUMP_PATH)
     finally:
-        terminate_and_wait(devnet_proc)
+        ACTIVE_DEVNET.stop()
 
 def test_loading_via_cli():
     """Test dumping via endpoint and loading via CLI."""
     # init devnet + contract
-    devnet_proc = run_devnet_in_background()
+    ACTIVE_DEVNET.start()
     contract_address = deploy_empty_contract()
 
     invoke("increase_balance", ["10", "20"], contract_address, ABI_PATH)
@@ -125,12 +146,12 @@ def test_loading_via_cli():
 
     dump_and_assert(DUMP_PATH)
 
-    terminate_and_wait(devnet_proc)
+    ACTIVE_DEVNET.stop()
     assert_not_alive()
 
     # spawn new devnet and load path through CLI
-    loaded_devnet_proc = run_devnet_in_background("--load-path", DUMP_PATH)
-  
+    ACTIVE_DEVNET.start("--load-path", DUMP_PATH)
+
     loaded_balance = call("get_balance", contract_address, ABI_PATH)
     assert loaded_balance == balance_after_invoke
 
@@ -140,13 +161,13 @@ def test_loading_via_cli():
     assert balance_after_invoke_on_loaded == "70"
 
     os.remove(DUMP_PATH)
-    terminate_and_wait(loaded_devnet_proc)
+    ACTIVE_DEVNET.stop()
     assert_no_dump_present(DUMP_PATH)
 
 def test_dumping_and_loading_via_endpoint():
     """Test dumping and loading via endpoint."""
     # init devnet + contract
-    devnet_proc = run_devnet_in_background()
+    ACTIVE_DEVNET.start()
     contract_address = deploy_empty_contract()
 
     invoke("increase_balance", ["10", "20"], contract_address, ABI_PATH)
@@ -155,13 +176,13 @@ def test_dumping_and_loading_via_endpoint():
 
     dump_and_assert(DUMP_PATH)
 
-    terminate_and_wait(devnet_proc)
+    ACTIVE_DEVNET.stop()
     assert_not_alive()
 
     # spawn new devnet and load path via endpoint call
-    loaded_devnet_proc = run_devnet_in_background()
+    ACTIVE_DEVNET.start()
     send_load_request(DUMP_PATH)
-  
+
     loaded_balance = call("get_balance", contract_address, ABI_PATH)
     assert loaded_balance == balance_after_invoke
 
@@ -171,12 +192,12 @@ def test_dumping_and_loading_via_endpoint():
     assert balance_after_invoke_on_loaded == "70"
 
     os.remove(DUMP_PATH)
-    terminate_and_wait(loaded_devnet_proc)
+    ACTIVE_DEVNET.stop()
     assert_no_dump_present(DUMP_PATH)
 
 def test_dumping_on_exit():
     """Test dumping on exit."""
-    devnet_proc = run_devnet_in_background("--dump-on", "exit", "--dump-path", DUMP_PATH,sleep_seconds=3)
+    devnet_proc = ACTIVE_DEVNET.start("--dump-on", "exit", "--dump-path", DUMP_PATH, sleep_seconds=3)
     try:
         contract_address = deploy_empty_contract()
 
@@ -185,14 +206,14 @@ def test_dumping_on_exit():
         assert balance_after_invoke == "30"
 
         assert_no_dump_present(DUMP_PATH)
-        devnet_proc.send_signal(signal.SIGINT) # simulate Ctrl+C because devnet can't handle kill
+        devnet_proc.send_signal(signal.SIGINT) # send SIGINT because devnet doesn't handle SIGKILL
         assert_dump_present(DUMP_PATH, sleep_seconds=3)
     finally:
-        terminate_and_wait(devnet_proc)
+        ACTIVE_DEVNET.stop()
 
 def test_invalid_dump_on_option():
     """Test behavior when invalid dump-on is provided."""
-    devnet_proc = run_devnet_in_background(
+    devnet_proc = ACTIVE_DEVNET.start(
         "--dump-on", "obviously-invalid",
         "--dump-path", DUMP_PATH,
         stderr=subprocess.PIPE
@@ -204,11 +225,11 @@ def test_invalid_dump_on_option():
         expected_msg = b"Error: Invalid --dump-on option: obviously-invalid. Valid options: exit, transaction\n"
         assert devnet_proc.stderr.read() == expected_msg
     finally:
-        terminate_and_wait(devnet_proc)
+        ACTIVE_DEVNET.stop()
 
 def test_dump_path_not_present_with_dump_on_present():
     """Test behavior when dump-path is not present and dump-on is."""
-    devnet_proc = run_devnet_in_background("--dump-on", "exit", stderr=subprocess.PIPE)
+    devnet_proc = ACTIVE_DEVNET.start("--dump-on", "exit", stderr=subprocess.PIPE)
     devnet_proc.wait()
 
     try:
@@ -216,20 +237,22 @@ def test_dump_path_not_present_with_dump_on_present():
         expected_msg = b"Error: --dump-path required if --dump-on present\n"
         assert devnet_proc.stderr.read() == expected_msg
     finally:
-        terminate_and_wait(devnet_proc)
+        ACTIVE_DEVNET.stop()
 
 def assert_load(dump_path: str, contract_address: str, expected_value: str):
     """Load from `dump_path` and assert get_balance at `contract_address` returns `expected_value`."""
-    devnet_loaded_proc = run_devnet_in_background("--load-path", dump_path)
+    ACTIVE_DEVNET.start("--load-path", dump_path)
     try:
         assert call("get_balance", contract_address, ABI_PATH) == expected_value
     finally:
-        terminate_and_wait(devnet_loaded_proc)
+        ACTIVE_DEVNET.stop()
         os.remove(dump_path)
 
+
+# @devnet_in_background("--dump-on", "transaction", "--dump-path", DUMP_PATH)
 def test_dumping_on_each_tx():
     """Test dumping on each transaction."""
-    devnet_proc = run_devnet_in_background("--dump-on", "transaction", "--dump-path", DUMP_PATH)
+    ACTIVE_DEVNET.start("--dump-on", "transaction", "--dump-path", DUMP_PATH)
 
     try:
         # deploy
@@ -244,12 +267,12 @@ def test_dumping_on_each_tx():
         dump_after_invoke_path = "dump_after_invoke.pkl"
         os.rename(DUMP_PATH, dump_after_invoke_path)
 
-        terminate_and_wait(devnet_proc)
+        ACTIVE_DEVNET.stop()
 
         assert_load(dump_after_deploy_path, contract_address, "0")
         assert_load(dump_after_invoke_path, contract_address, "10")
     finally:
-        terminate_and_wait(devnet_proc)
+        ACTIVE_DEVNET.stop()
 
 @devnet_in_background()
 def test_dumping_call_with_invalid_body():


### PR DESCRIPTION
## Usage related changes

- The `/load` endpoint allows quickly loading a previously stored Starknet chain state. This can be used for unit testing to quickly restore state between dozens of test cases
- Updated README with a simple example

## Development related changes

- Added `load()` route into [blueprints/base.py](https://github.com/Shard-Labs/starknet-devnet/pull/134/files#diff-e36acc44798507ebeb37099b01e300126d5bd4d2c1889748ae7cd62f03d82c4a)
- Expanded `test_dump.py` to handle endpoint and non-endpoint based loading
- Added current active devnet process handling to `test_dump.py`

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the base branch
- [x] Documented the changes
- [x] Updated the tests
- [x] All tests are passing
