### PR TITLE
Improve background running of Devnet in tests

### DIFF
--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -21,10 +21,10 @@ class DevnetBackgroundProc:
     def __init__(self):
         self.proc = None
 
-    def start(self, *args, sleep_seconds=5, stderr=None, stdout=None):
+    def start(self, *args, stderr=None, stdout=None):
         """ Starts a new devnet-server instance. Previously active instance will be stopped. """
         self.stop()
-        self.proc = run_devnet_in_background(*args, sleep_seconds=sleep_seconds, stderr=stderr, stdout=stdout)
+        self.proc = run_devnet_in_background(*args, stderr=stderr, stdout=stdout)
         return self.proc
 
     def stop(self):
@@ -197,7 +197,7 @@ def test_dumping_and_loading_via_endpoint():
 
 def test_dumping_on_exit():
     """Test dumping on exit."""
-    devnet_proc = ACTIVE_DEVNET.start("--dump-on", "exit", "--dump-path", DUMP_PATH, sleep_seconds=3)
+    devnet_proc = ACTIVE_DEVNET.start("--dump-on", "exit", "--dump-path", DUMP_PATH)
     try:
         contract_address = deploy_empty_contract()
 

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -107,32 +107,22 @@ def test_load_if_no_file():
     """Test loading if dump file not present."""
     assert_no_dump_present(DUMP_PATH)
     devnet_proc = ACTIVE_DEVNET.start("--load-path", DUMP_PATH, stderr=subprocess.PIPE)
-    devnet_proc.wait()
-    try:
-        assert devnet_proc.returncode != 0
-        expected_msg = f"Error: Cannot load from {DUMP_PATH}. Make sure the file exists and contains a Devnet dump.\n"
-        assert expected_msg == devnet_proc.stderr.read().decode("utf-8")
-    finally:
-        ACTIVE_DEVNET.stop()
+    assert devnet_proc.returncode != 0
+    expected_msg = f"Error: Cannot load from {DUMP_PATH}. Make sure the file exists and contains a Devnet dump.\n"
+    assert expected_msg == devnet_proc.stderr.read().decode("utf-8")
 
+@devnet_in_background()
 def test_dumping_if_path_not_provided():
     """Assert failure if dumping attempted without a known path."""
-    ACTIVE_DEVNET.start()
-    try:
-        resp = send_dump_request()
-        assert resp.status_code == 400
-    finally:
-        ACTIVE_DEVNET.stop()
+    resp = send_dump_request()
+    assert resp.status_code == 400
 
+@devnet_in_background("--dump-path", DUMP_PATH)
 def test_dumping_if_path_provided_as_cli_option():
     """Test dumping if path provided as CLI option"""
-    ACTIVE_DEVNET.start("--dump-path", DUMP_PATH)
-    try:
-        resp = send_dump_request()
-        assert resp.status_code == 200
-        assert_dump_present(DUMP_PATH)
-    finally:
-        ACTIVE_DEVNET.stop()
+    resp = send_dump_request()
+    assert resp.status_code == 200
+    assert_dump_present(DUMP_PATH)
 
 def test_loading_via_cli():
     """Test dumping via endpoint and loading via CLI."""
@@ -198,18 +188,16 @@ def test_dumping_and_loading_via_endpoint():
 def test_dumping_on_exit():
     """Test dumping on exit."""
     devnet_proc = ACTIVE_DEVNET.start("--dump-on", "exit", "--dump-path", DUMP_PATH)
-    try:
-        contract_address = deploy_empty_contract()
 
-        invoke("increase_balance", ["10", "20"], contract_address, ABI_PATH)
-        balance_after_invoke = call("get_balance", contract_address, ABI_PATH)
-        assert balance_after_invoke == "30"
+    contract_address = deploy_empty_contract()
 
-        assert_no_dump_present(DUMP_PATH)
-        devnet_proc.send_signal(signal.SIGINT) # send SIGINT because devnet doesn't handle SIGKILL
-        assert_dump_present(DUMP_PATH, sleep_seconds=3)
-    finally:
-        ACTIVE_DEVNET.stop()
+    invoke("increase_balance", ["10", "20"], contract_address, ABI_PATH)
+    balance_after_invoke = call("get_balance", contract_address, ABI_PATH)
+    assert balance_after_invoke == "30"
+
+    assert_no_dump_present(DUMP_PATH)
+    devnet_proc.send_signal(signal.SIGINT) # send SIGINT because devnet doesn't handle SIGKILL
+    assert_dump_present(DUMP_PATH, sleep_seconds=3)
 
 def test_invalid_dump_on_option():
     """Test behavior when invalid dump-on is provided."""
@@ -218,61 +206,47 @@ def test_invalid_dump_on_option():
         "--dump-path", DUMP_PATH,
         stderr=subprocess.PIPE
     )
-    devnet_proc.wait()
 
-    try:
-        assert devnet_proc.returncode != 0
-        expected_msg = b"Error: Invalid --dump-on option: obviously-invalid. Valid options: exit, transaction\n"
-        assert devnet_proc.stderr.read() == expected_msg
-    finally:
-        ACTIVE_DEVNET.stop()
+    assert devnet_proc.returncode != 0
+    expected_msg = b"Error: Invalid --dump-on option: obviously-invalid. Valid options: exit, transaction\n"
+    assert devnet_proc.stderr.read() == expected_msg
 
 def test_dump_path_not_present_with_dump_on_present():
     """Test behavior when dump-path is not present and dump-on is."""
     devnet_proc = ACTIVE_DEVNET.start("--dump-on", "exit", stderr=subprocess.PIPE)
-    devnet_proc.wait()
 
-    try:
-        assert devnet_proc.returncode != 0
-        expected_msg = b"Error: --dump-path required if --dump-on present\n"
-        assert devnet_proc.stderr.read() == expected_msg
-    finally:
-        ACTIVE_DEVNET.stop()
+    assert devnet_proc.returncode != 0
+    expected_msg = b"Error: --dump-path required if --dump-on present\n"
+    assert devnet_proc.stderr.read() == expected_msg
 
 def assert_load(dump_path: str, contract_address: str, expected_value: str):
     """Load from `dump_path` and assert get_balance at `contract_address` returns `expected_value`."""
+
     ACTIVE_DEVNET.start("--load-path", dump_path)
-    try:
-        assert call("get_balance", contract_address, ABI_PATH) == expected_value
-    finally:
-        ACTIVE_DEVNET.stop()
-        os.remove(dump_path)
+    assert call("get_balance", contract_address, ABI_PATH) == expected_value
+    ACTIVE_DEVNET.stop()
+    os.remove(dump_path)
 
-
-# @devnet_in_background("--dump-on", "transaction", "--dump-path", DUMP_PATH)
 def test_dumping_on_each_tx():
     """Test dumping on each transaction."""
     ACTIVE_DEVNET.start("--dump-on", "transaction", "--dump-path", DUMP_PATH)
 
-    try:
-        # deploy
-        contract_address = deploy_empty_contract()
-        assert_dump_present(DUMP_PATH)
-        dump_after_deploy_path = "dump_after_deploy.pkl"
-        os.rename(DUMP_PATH, dump_after_deploy_path)
+    # deploy
+    contract_address = deploy_empty_contract()
+    assert_dump_present(DUMP_PATH)
+    dump_after_deploy_path = "dump_after_deploy.pkl"
+    os.rename(DUMP_PATH, dump_after_deploy_path)
 
-        # invoke
-        invoke("increase_balance", ["5", "5"], contract_address, ABI_PATH)
-        assert_dump_present(DUMP_PATH)
-        dump_after_invoke_path = "dump_after_invoke.pkl"
-        os.rename(DUMP_PATH, dump_after_invoke_path)
+    # invoke
+    invoke("increase_balance", ["5", "5"], contract_address, ABI_PATH)
+    assert_dump_present(DUMP_PATH)
+    dump_after_invoke_path = "dump_after_invoke.pkl"
+    os.rename(DUMP_PATH, dump_after_invoke_path)
 
-        ACTIVE_DEVNET.stop()
+    ACTIVE_DEVNET.stop()
 
-        assert_load(dump_after_deploy_path, contract_address, "0")
-        assert_load(dump_after_invoke_path, contract_address, "10")
-    finally:
-        ACTIVE_DEVNET.stop()
+    assert_load(dump_after_deploy_path, contract_address, "0")
+    assert_load(dump_after_invoke_path, contract_address, "10")
 
 @devnet_in_background()
 def test_dumping_call_with_invalid_body():

--- a/test/test_postman.py
+++ b/test/test_postman.py
@@ -3,12 +3,11 @@ Test postman usage. This test has one single pytest case, because the whole flow
 """
 
 import json
-import time
 import subprocess
 
 from test.web3_util import web3_call, web3_deploy, web3_transact
-from test.settings import L1_URL, GATEWAY_URL
-from test.util import call, deploy, devnet_in_background, invoke, load_file_content, terminate_and_wait
+from test.settings import L1_HOST, L1_PORT, L1_URL, GATEWAY_URL
+from test.util import call, deploy, devnet_in_background, ensure_server_alive, invoke, load_file_content, terminate_and_wait
 
 import psutil
 import pytest
@@ -31,11 +30,13 @@ def run_before_and_after_test():
     """Run l1 testnet before and kill it after the test run"""
     # Setup L1 testnet
 
-    command = ["npx", "hardhat", "node"]
+    command = ["npx", "hardhat", "node", "--hostname", L1_HOST, "--port", L1_PORT]
     with subprocess.Popen(command, close_fds=True) as node_proc:
         # before test
-        time.sleep(10)
+        ensure_server_alive(L1_URL, node_proc)
+
         yield
+
         # after test
         wrapped_node_proc = psutil.Process(node_proc.pid)
         children = wrapped_node_proc.children(recursive=True)

--- a/test/util.py
+++ b/test/util.py
@@ -7,19 +7,20 @@ import os
 import re
 import subprocess
 import time
+import requests
 
 from starkware.starknet.services.api.contract_class import ContractClass
 
 from starknet_devnet.general_config import DEFAULT_GENERAL_CONFIG
-from .settings import GATEWAY_URL, FEEDER_GATEWAY_URL, HOST, PORT
+from .settings import GATEWAY_URL, FEEDER_GATEWAY_URL, HOST, PORT, APP_URL
 
 class ReturnCodeAssertionError(AssertionError):
     """Error to be raised when the return code of an executed process is not as expected."""
 
-def run_devnet_in_background(*args, sleep_seconds=5, stderr=None, stdout=None):
+def run_devnet_in_background(*args, stderr=None, stdout=None):
     """
     Runs starknet-devnet in background.
-    By default sleeps 5 second after spawning devnet.
+    Sleep before devnet is responsive.
     Accepts extra args to pass to `starknet-devnet` command.
     Returns the process handle.
     """
@@ -27,7 +28,7 @@ def run_devnet_in_background(*args, sleep_seconds=5, stderr=None, stdout=None):
     # pylint: disable=consider-using-with
     proc = subprocess.Popen(command, close_fds=True, stderr=stderr, stdout=stdout)
 
-    time.sleep(sleep_seconds)
+    ensure_server_alive(f"{APP_URL}/is_alive", proc)
     return proc
 
 def devnet_in_background(*devnet_args, **devnet_kwargs):
@@ -49,6 +50,26 @@ def terminate_and_wait(proc: subprocess.Popen):
     """Terminates the process and waits."""
     proc.terminate()
     proc.wait()
+
+def ensure_server_alive(url: str, proc: subprocess.Popen, check_period=0.5, max_wait=60):
+    """
+    Ensures server at provided `url` is alive.
+    Checks every `check_period` seconds.
+    Fails after `max_wait` seconds - terminates the server's `proc`.
+    """
+
+    n_checks = int(max_wait // check_period)
+    for _ in range(n_checks):
+        try:
+            requests.get(url)
+            return
+        except requests.exceptions.ConnectionError:
+            pass
+
+        time.sleep(check_period)
+
+    terminate_and_wait(proc)
+    raise RuntimeError(f"max_wait time {max_wait} exceeded while checking {url}")
 
 def assert_equal(actual, expected, explanation=None):
     """Assert that the two values are equal. Optionally provide explanation."""

--- a/test/util.py
+++ b/test/util.py
@@ -53,13 +53,17 @@ def terminate_and_wait(proc: subprocess.Popen):
 
 def ensure_server_alive(url: str, proc: subprocess.Popen, check_period=0.5, max_wait=60):
     """
-    Ensures server at provided `url` is alive.
+    Ensures that server at provided `url` is alive or that `proc` has terminated.
     Checks every `check_period` seconds.
     Fails after `max_wait` seconds - terminates the server's `proc`.
     """
 
     n_checks = int(max_wait // check_period)
     for _ in range(n_checks):
+        if proc.poll() is not None:
+            # if process has terminated, return
+            return
+
         try:
             requests.get(url)
             return


### PR DESCRIPTION
## Usage related changes

None

## Development related changes

- After spawning a subprocess, instead of sleeping for a fixed number of seconds to let the process start up, sleep for a short period, check and repeat in a loop.
- `sleep_seconds` only remains as a parameter in those tests where dumps are asserted to be present or not once devnet is dead.
- Stop using the try-finally paradigm in test_dump.py tests - rely on the new background process handler class.
  - The majority of the changed-line count comes from this change.
  - Where possible having `ACTIVE_DEVNET.start()` in test body was replaced with the `@devnet_in_background()` decorator.
- Improve Postman test - explicitly specify host and port instead of using the default values.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the base branch
- [x] Documented the changes
- [x] Updated the tests
- [x] All tests are passing
