### PR TITLE
Zero pre deployed account as default

### DIFF
--- a/test/util.py
+++ b/test/util.py
@@ -2,7 +2,6 @@
 File containing functions that wrap Starknet CLI commands.
 """
 
-from ast import arg
 import json
 import os
 import re
@@ -35,7 +34,7 @@ def run_devnet_in_background(*args, stderr=None, stdout=None):
 
     ensure_server_alive(f"{APP_URL}/is_alive", proc)
     return proc
- 
+
 def devnet_in_background(*devnet_args, **devnet_kwargs):
     """
     Decorator that runs devnet in background and later kills it.

--- a/test/util.py
+++ b/test/util.py
@@ -2,6 +2,7 @@
 File containing functions that wrap Starknet CLI commands.
 """
 
+from ast import arg
 import json
 import os
 import re
@@ -24,13 +25,17 @@ def run_devnet_in_background(*args, stderr=None, stdout=None):
     Accepts extra args to pass to `starknet-devnet` command.
     Returns the process handle.
     """
+    # If accounts argument is not passed 0 is used as default
+    if "--accounts" not in args:
+        args = [*args, "--accounts", "0"]
+
     command = ["poetry", "run", "starknet-devnet", "--host", HOST, "--port", PORT, *args]
     # pylint: disable=consider-using-with
     proc = subprocess.Popen(command, close_fds=True, stderr=stderr, stdout=stdout)
 
     ensure_server_alive(f"{APP_URL}/is_alive", proc)
     return proc
-
+ 
 def devnet_in_background(*devnet_args, **devnet_kwargs):
     """
     Decorator that runs devnet in background and later kills it.


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

- By default zero pre-deployed account is used in args for tests that use `devnet_in_background()`

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

- Improves logging and time during the test

## Checklist:

- [x] No linter errors
- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [x] Linked the issues which this PR. Closes #150 
- [ ] Updated the tests
- [x] All tests are passing
