### PR TITLE
Fix geth --dev support in postman

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ Loads a `StarknetMockMessaging` contract. The `address` parameter is optional; i
 `networkUrl` is the URL of the JSON-RPC API of the L1 node you've run locally or that already exists; possibilities include, and are not limited to:
 
 - [Goerli testnet](https://goerli.net/)
-- [Ganache node](https://www.npmjs.com/package/ganache)
+- [Ganache](https://www.npmjs.com/package/ganache)
+- [Geth](https://github.com/ethereum/go-ethereum#docker-quick-start)
 - [Hardhat node](https://hardhat.org/hardhat-network/#running-stand-alone-in-order-to-support-wallets-and-other-software).
 
 ### Postman - Flush

--- a/starknet_devnet/postman_wrapper.py
+++ b/starknet_devnet/postman_wrapper.py
@@ -5,6 +5,7 @@ import json
 
 from abc import ABC, abstractmethod
 from web3 import HTTPProvider, Web3
+from web3.middleware import geth_poa_middleware
 
 from starkware.solidity.utils import load_nearby_contract
 from starkware.starknet.testing.postman import Postman
@@ -127,6 +128,7 @@ class LocalPostmanWrapper(PostmanWrapper):
         super().__init__()
         request_kwargs = {"timeout": TIMEOUT_FOR_WEB3_REQUESTS}
         self.web3 = Web3(HTTPProvider(network_url, request_kwargs=request_kwargs))
+        self.web3.middleware_onion.inject(geth_poa_middleware, layer=0)
         self.eth_account = EthAccount(self.web3,self.web3.eth.accounts[0])
 
     def load_mock_messaging_contract_in_l1(self, starknet, contract_address):


### PR DESCRIPTION
## Usage related changes

- Enable using Postman if L1 is geth in dev mode (uses POA so requires middleware)
- Tested the change, works with:
  - `hardhat node`
  - `ganache`
  - `geth` in dev mode

## Development related changes

None

## Checklist:

- [x] No linter errors
- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] All tests are passing
