### PR TITLE
Add dump path check

### DIFF
--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -5,7 +5,7 @@ from flask import Blueprint, Response, request, jsonify
 from starknet_devnet.fee_token import FeeToken
 
 from starknet_devnet.state import state
-from starknet_devnet.util import StarknetDevnetException
+from starknet_devnet.util import StarknetDevnetException, check_valid_dump_path
 
 base = Blueprint("base", __name__)
 
@@ -60,6 +60,11 @@ def dump():
     dump_path = request_dict.get("path") or state.dumper.dump_path
     if not dump_path:
         raise StarknetDevnetException(message="No path provided.", status_code=400)
+
+    try:
+        check_valid_dump_path(dump_path)
+    except ValueError as error:
+        raise StarknetDevnetException(status_code=400, message=str(error)) from error
 
     state.dumper.dump(dump_path)
     return Response(status=200)

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -2,7 +2,6 @@
 A server exposing Starknet functionalities as API endpoints.
 """
 
-import os
 from pickle import UnpicklingError
 import sys
 
@@ -16,7 +15,7 @@ from .blueprints.gateway import gateway
 from .blueprints.feeder_gateway import feeder_gateway
 from .blueprints.postman import postman
 from .blueprints.rpc import rpc
-from .util import DumpOn, parse_args
+from .util import DumpOn, check_valid_dump_path, parse_args
 from .starknet_wrapper import DevnetConfig
 from .state import state
 
@@ -43,21 +42,14 @@ def generate_accounts(args):
             seed=args.seed
         )
 
-def _check_dump_path(dump_path: str):
-    """Checks if dump path is a directory."""
-    dump_path_dir = os.path.dirname(dump_path)
-
-    if not dump_path_dir:
-        # dump_path is just a file, with no parent dir
-        return
-
-    if not os.path.isdir(dump_path_dir):
-        sys.exit(f"Error: Invalid dump path: directory '{dump_path_dir}' not found.")
-
 def set_dump_options(args):
     """Assign dumping options from args to state."""
     if args.dump_path:
-        _check_dump_path(args.dump_path)
+        try:
+            check_valid_dump_path(args.dump_path)
+        except ValueError as error:
+            sys.exit(str(error))
+
     state.dumper.dump_path = args.dump_path
     state.dumper.dump_on = args.dump_on
 

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -46,6 +46,11 @@ def generate_accounts(args):
 def _check_dump_path(dump_path: str):
     """Checks if dump path is a directory."""
     dump_path_dir = os.path.dirname(dump_path)
+
+    if not dump_path_dir:
+        # dump_path is just a file, with no parent dir
+        return
+
     if not os.path.isdir(dump_path_dir):
         sys.exit(f"Error: Invalid dump path: directory '{dump_path_dir}' not found.")
 

--- a/starknet_devnet/util.py
+++ b/starknet_devnet/util.py
@@ -2,9 +2,10 @@
 Utility functions used across the project.
 """
 
+import argparse
 from dataclasses import dataclass
 from enum import Enum, auto
-import argparse
+import os
 import sys
 from typing import List, Dict, Union
 
@@ -302,3 +303,15 @@ def to_bytes(value: Union[int, bytes]) -> bytes:
     If bytes, return the received value
     """
     return value if isinstance(value, bytes) else value.to_bytes(32, "big")
+
+def check_valid_dump_path(dump_path: str):
+    """Checks if dump path is a directory. Raises ValueError if not."""
+
+    dump_path_dir = os.path.dirname(dump_path)
+
+    if not dump_path_dir:
+        # dump_path is just a file, with no parent dir
+        return
+
+    if not os.path.isdir(dump_path_dir):
+        raise ValueError(f"Invalid dump path: directory '{dump_path_dir}' not found.")

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -107,7 +107,7 @@ def test_load_if_no_file():
     """Test loading if dump file not present."""
     assert_no_dump_present(DUMP_PATH)
     devnet_proc = ACTIVE_DEVNET.start("--load-path", DUMP_PATH, stderr=subprocess.PIPE)
-    assert devnet_proc.returncode != 0
+    assert devnet_proc.returncode == 1
     expected_msg = f"Error: Cannot load from {DUMP_PATH}. Make sure the file exists and contains a Devnet dump.\n"
     assert expected_msg == devnet_proc.stderr.read().decode("utf-8")
 
@@ -116,6 +116,16 @@ def test_dumping_if_path_not_provided():
     """Assert failure if dumping attempted without a known path."""
     resp = send_dump_request()
     assert resp.status_code == 400
+
+def test_dumping_if_nonexistent_directory():
+    """Assert failure if dumping attempted with a path containing a non-existent directory."""
+    nonexistent_dir = "nonexistent-dir"
+    invalid_path = os.path.join(nonexistent_dir, DUMP_PATH)
+    devnet_proc = ACTIVE_DEVNET.start("--dump-path", invalid_path, stderr=subprocess.PIPE)
+    assert devnet_proc.returncode == 1
+
+    expected_msg = f"Error: Invalid dump path: directory '{nonexistent_dir}' not found.\n"
+    assert expected_msg == devnet_proc.stderr.read().decode("utf-8")
 
 @devnet_in_background("--dump-path", DUMP_PATH)
 def test_dumping_if_path_provided_as_cli_option():
@@ -207,7 +217,7 @@ def test_invalid_dump_on_option():
         stderr=subprocess.PIPE
     )
 
-    assert devnet_proc.returncode != 0
+    assert devnet_proc.returncode == 1
     expected_msg = b"Error: Invalid --dump-on option: obviously-invalid. Valid options: exit, transaction\n"
     assert devnet_proc.stderr.read() == expected_msg
 
@@ -215,7 +225,7 @@ def test_dump_path_not_present_with_dump_on_present():
     """Test behavior when dump-path is not present and dump-on is."""
     devnet_proc = ACTIVE_DEVNET.start("--dump-on", "exit", stderr=subprocess.PIPE)
 
-    assert devnet_proc.returncode != 0
+    assert devnet_proc.returncode == 1
     expected_msg = b"Error: --dump-path required if --dump-on present\n"
     assert devnet_proc.stderr.read() == expected_msg
 

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -117,15 +117,25 @@ def test_dumping_if_path_not_provided():
     resp = send_dump_request()
     assert resp.status_code == 400
 
-def test_dumping_if_nonexistent_directory():
-    """Assert failure if dumping attempted with a path containing a non-existent directory."""
-    nonexistent_dir = "nonexistent-dir"
-    invalid_path = os.path.join(nonexistent_dir, DUMP_PATH)
+NONEXISTENT_DIR = "nonexistent-dir"
+
+def test_dumping_if_nonexistent_dir_via_cli():
+    """Assert failure if dumping attempted via cli with a path containing a nonexistent dir"""
+    invalid_path = os.path.join(NONEXISTENT_DIR, DUMP_PATH)
     devnet_proc = ACTIVE_DEVNET.start("--dump-path", invalid_path, stderr=subprocess.PIPE)
     assert devnet_proc.returncode == 1
 
-    expected_msg = f"Error: Invalid dump path: directory '{nonexistent_dir}' not found.\n"
+    expected_msg = f"Invalid dump path: directory '{NONEXISTENT_DIR}' not found.\n"
     assert expected_msg == devnet_proc.stderr.read().decode("utf-8")
+
+@devnet_in_background()
+def test_dumping_if_nonexistent_dir_via_http():
+    """Assert failure if dumping attempted via http with a path containing a nonexistent dir"""
+    invalid_path = os.path.join(NONEXISTENT_DIR, DUMP_PATH)
+
+    resp = send_dump_request(dump_path=invalid_path)
+    assert resp.json()["message"] == f"Invalid dump path: directory '{NONEXISTENT_DIR}' not found."
+    assert resp.status_code == 400
 
 @devnet_in_background("--dump-path", DUMP_PATH)
 def test_dumping_if_path_provided_as_cli_option():


### PR DESCRIPTION
## Usage related changes

- Check if the directory of the dump paths exists (when specified through CLI and through HTTP).

## Development related changes

- Alphabetically sort imports in some files.
- Change dump tests to explicitly check for status code == 1
- Change order of `set_dump_options` and `generate_accounts` so that failure in case of an invalid dump path happens sooner.

## Checklist:

- [x] No linter errors
- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Updated the tests
- [x] All tests are passing
