### PR TITLE
Build and push docker image with --seed 0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
           command: ./scripts/image_build_and_push.sh
           environment:
             ARCH_SUFFIX: -arm
+            REMOTE: ""
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ jobs:
           name: Build and push image
           command: ./scripts/image_build_and_push.sh
           environment:
+            ARCH_SUFFIX: ""
             REMOTE: true
 
   image_build_and_push_arm:
@@ -85,7 +86,7 @@ jobs:
           name: Build and push image
           command: ./scripts/image_build_and_push.sh
           environment:
-            TAG_SUFFIX: -arm
+            ARCH_SUFFIX: -arm
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ Image tags correspond to Devnet versions as on PyPI and GitHub, with the `latest
 
 - `shardlabs/starknet-devnet:0.2.5` - image for the amd64 architecture
 - `shardlabs/starknet-devnet:0.2.5-arm` - image for the arm64 architecture
+- `shardlabs/starknet-devnet:latest-arm`
+
+By appending the `-seed0` suffix, you can access images which [predeploy funded accounts](#predeployed-accounts) with `--seed 0`, thus always deploying the same set of accounts. E.g.:
+
+- `shardlabs/starknet-devnet:0.2.5-seed0`
+- `shardlabs/starknet-devnet:latest-seed0`
+- `shardlabs/starknet-devnet:0.2.5-arm-seed0`
 
 The server inside the container listens to the port 5050, which you need to publish to a desired `<PORT>` on your host machine:
 

--- a/scripts/image_build_and_push.sh
+++ b/scripts/image_build_and_push.sh
@@ -20,21 +20,20 @@ LOCAL_VERSION_SEEDED_TAG="${LOCAL_VERSION_TAG}${SEED_SUFFIX}"
 LATEST_VERSION_SEEDED_TAG="${LATEST_VERSION_TAG}${SEED_SUFFIX}"
 docker build . \
     -f seed0.Dockerfile \
-    --build-arg BASE_TAG=$LOCAL_VERSION_TAG
+    --build-arg BASE_TAG=$LOCAL_VERSION_TAG \
     -t "$IMAGE:$LOCAL_VERSION_SEEDED_TAG" \
     -t "$IMAGE:$LATEST_VERSION_SEEDED_TAG" \
 
 echo "Run a devnet instance in background; sleep to allow it to start"
-# can't use "localhost" because docker doesn't allow such mapping
 docker run -d -p 127.0.0.1:5050:5050 --name devnet "$IMAGE:$LATEST_VERSION_TAG"
 sleep 10
 docker logs devnet
 
 echo "Checking if devnet instance is alive"
 if [ ! -z $REMOTE ]; then
-    ssh remote-docker curl localhost:5050/is_alive
+    ssh remote-docker curl localhost:5050/is_alive -w "\n"
 else
-    curl localhost:5050/is_alive
+    curl localhost:5050/is_alive -w "\n"
 fi
 
 # curling the url fails with 404

--- a/seed0.Dockerfile
+++ b/seed0.Dockerfile
@@ -1,0 +1,5 @@
+ARG BASE_TAG
+
+FROM shardlabs/starknet-devnet:${BASE_TAG}
+
+ENTRYPOINT [ "starknet-devnet", "--host", "0.0.0.0", "--port", "5050", "--seed", "0" ]


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

- Closes #174
- After doing the usual build, a preseeded image will be built (with `--seed 0`), resulting in the following new images:
  - `shardlabs/starknet-devnet:0.2.5-seed0`
  - `shardlabs/starknet-devnet:latest-seed0`
  - `shardlabs/starknet-devnet:0.2.5-arm-seed0`
  - `shardlabs/starknet-devnet:latest-arm-seed0`

## Development related changes

- Add `seed0.Dockerfile`
- Rename `TAG_SUFFIX` to `ARCH_SUFFIX`
- Introduce `SEED_SUFFIX`

## Checklist:

- [x] No linter errors
- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Built locally to see if it works
