### PR TITLE
Add endpoint to get fee token address

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,21 @@ Other than using prefunded predeployed accounts, you can also add funds to an ac
 
 The ERC20 contract used for minting ETH tokens and charging fees is at: `0x62230ea046a9a5fbc261ac77d03c8d41e5d442db2284587570ab46455fd2488`
 
+### Query fee token address
+
+```
+GET /fee_token
+```
+
+Response:
+
+```
+{
+  "symbol":"ETH",
+  "address":"0x62230ea046a9a5fbc261ac77d03c8d41e5d442db2284587570ab46455fd2488",
+}
+```
+
 ### Mint with a transaction
 
 By not setting the `lite` parameter or by setting it to `false`, new tokens will be minted in a separate transaction. You will receive the hash of this transaction, as well as the new balance after minting in the response.

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -123,7 +123,7 @@ async def get_fee_token():
     """Get the address of the fee token"""
     fee_token_address = FeeToken.ADDRESS
     symbol = FeeToken.SYMBOL
-    return jsonify({"symbol": symbol, "address": fee_token_address})
+    return jsonify({"symbol": symbol, "address": hex(fee_token_address)})
 
 @base.route("/mint", methods=["POST"])
 async def mint():

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -118,6 +118,13 @@ def get_predeployed_accounts():
     accounts = state.starknet_wrapper.accounts
     return jsonify([account.to_json() for account in accounts])
 
+@base.route("/fee_token", methods=["GET"])
+async def get_fee_token():
+    """Get the address of the fee token"""
+    fee_token_address = FeeToken.ADDRESS
+    symbol = FeeToken.SYMBOL
+    return jsonify({"symbol": symbol, "address": fee_token_address})
+
 @base.route("/mint", methods=["POST"])
 async def mint():
     """Mint token and transfer to the provided address"""

--- a/starknet_devnet/fee_token.py
+++ b/starknet_devnet/fee_token.py
@@ -27,6 +27,8 @@ class FeeToken:
     # ADDRESS = calculate_contract_address_from_hash(salt=10, class_hash=HASH,
     # constructor_calldata=[], caller_address=0)
     ADDRESS = 2774287484619332564597403632816768868845110259953541691709975889937073775752
+    SYMBOL = "ETH"
+    NAME = "ether"
 
     contract: StarknetContract = None
 
@@ -55,8 +57,8 @@ class FeeToken:
             state=newly_deployed_fee_token_state,
             storage_updates={
                 # Running the constructor doesn't need to be simulated
-                get_selector_from_name('ERC20_name'): StorageLeaf(int.from_bytes(bytes('ether', "ascii"), "big")),
-                get_selector_from_name('ERC20_symbol'): StorageLeaf(int.from_bytes(bytes('ETH', "ascii"), "big")),
+                get_selector_from_name('ERC20_name'): StorageLeaf(int.from_bytes(bytes(FeeToken.NAME, "ascii"), "big")),
+                get_selector_from_name('ERC20_symbol'): StorageLeaf(int.from_bytes(bytes(FeeToken.SYMBOL, "ascii"), "big")),
                 get_selector_from_name('ERC20_decimals'): StorageLeaf(18)
             }
         )

--- a/test/test_fee_token.py
+++ b/test/test_fee_token.py
@@ -14,6 +14,16 @@ def test_precomputed_address_unchanged():
     """Assert that the precomputed fee_token address is unchanged."""
     assert_equal(FeeToken.ADDRESS, 2774287484619332564597403632816768868845110259953541691709975889937073775752)
 
+@pytest.mark.fee_token
+@devnet_in_background()
+def test_fee_token_address():
+    """Sends fee token request;"""
+    response = requests.get(f"{APP_URL}/fee_token")
+    assert response.status_code == 200
+    assert response.json().get("address") == 2774287484619332564597403632816768868845110259953541691709975889937073775752
+    assert response.json().get("symbol") == "ETH"
+
+
 def mint(address: str, amount: int, lite=False):
     """Sends mint request; returns parsed json body"""
     response = requests.post(f"{APP_URL}/mint", json={

--- a/test/test_fee_token.py
+++ b/test/test_fee_token.py
@@ -20,7 +20,7 @@ def test_fee_token_address():
     """Sends fee token request;"""
     response = requests.get(f"{APP_URL}/fee_token")
     assert response.status_code == 200
-    assert response.json().get("address") == 2774287484619332564597403632816768868845110259953541691709975889937073775752
+    assert response.json().get("address") == "0x62230ea046a9a5fbc261ac77d03c8d41e5d442db2284587570ab46455fd2488"
     assert response.json().get("symbol") == "ETH"
 
 


### PR DESCRIPTION
Fixes issue #190 

## Usage related changes

<!-- How the changes from this PR affect users. -->

- New endpoint called `fee_token` returns the symbol and address of the fee token

## Development related changes

## Checklist:

- [X] No linter errors
- [X] Performed a self-review of the code
- [X] Rebased to the last commit of the target branch (or merged it into my branch)
- [X] Documented the changes
- [X] Linked the issues which this PR resolves
- [X] Updated the tests
- [X] All tests are passing
