### PR TITLE
Fix rpc declare and deploy parameters

### DIFF
--- a/starknet_devnet/blueprints/rpc.py
+++ b/starknet_devnet/blueprints/rpc.py
@@ -399,8 +399,8 @@ async def add_deploy_transaction(contract_address_salt: str, constructor_calldat
         raise RpcError(code=50, message="Invalid contract class") from ex
 
     deploy_transaction = Deploy(
-        contract_address_salt=contract_address_salt,
-        constructor_calldata=constructor_calldata,
+        contract_address_salt=int(contract_address_salt, 16),
+        constructor_calldata=[int(data, 16) for data in constructor_calldata],
         contract_definition=contract_class,
         version=constants.TRANSACTION_VERSION,
     )

--- a/starknet_devnet/blueprints/rpc.py
+++ b/starknet_devnet/blueprints/rpc.py
@@ -373,7 +373,7 @@ async def add_declare_transaction(contract_class: RpcContractClass, version: str
 
     declare_transaction = Declare(
         contract_class=contract_definition,
-        version=version,
+        version=int(version, 16),
         sender_address=DECLARE_SENDER_ADDRESS,
         max_fee=0,
         signature=[],

--- a/test/rpc/test_rpc_transactions.py
+++ b/test/rpc/test_rpc_transactions.py
@@ -365,7 +365,7 @@ def test_add_declare_transaction_on_incorrect_contract(declare_content):
         "starknet_addDeclareTransaction",
         params={
             "contract_class": rpc_contract,
-            "version": constants.TRANSACTION_VERSION,
+            "version": hex(constants.TRANSACTION_VERSION),
         }
     )
 

--- a/test/rpc/test_rpc_transactions.py
+++ b/test/rpc/test_rpc_transactions.py
@@ -405,6 +405,8 @@ def test_add_deploy_transaction_on_incorrect_contract(deploy_content):
     Add deploy transaction on incorrect class
     """
     contract_definition = deploy_content["contract_definition"]
+    salt = deploy_content["contract_address_salt"]
+    calldata = [hex(data) for data in deploy_content["constructor_calldata"]]
 
     rpc_contract = RpcContractClass(
         program="",
@@ -414,8 +416,8 @@ def test_add_deploy_transaction_on_incorrect_contract(deploy_content):
     ex = rpc_call(
         "starknet_addDeployTransaction",
         params={
-            "contract_address_salt": int(deploy_content["contract_address_salt"], 16),
-            "constructor_calldata": deploy_content["constructor_calldata"],
+            "contract_address_salt": salt,
+            "constructor_calldata": calldata,
             "contract_definition": rpc_contract,
         }
     )
@@ -431,6 +433,8 @@ def test_add_deploy_transaction(deploy_content):
     Add deploy transaction
     """
     contract_definition = deploy_content["contract_definition"]
+    salt = deploy_content["contract_address_salt"]
+    calldata = [hex(data) for data in deploy_content["constructor_calldata"]]
 
     rpc_contract = RpcContractClass(
         program=contract_definition["program"],
@@ -440,8 +444,8 @@ def test_add_deploy_transaction(deploy_content):
     resp = rpc_call(
         "starknet_addDeployTransaction",
         params={
-            "contract_address_salt": int(deploy_content["contract_address_salt"], 16),
-            "constructor_calldata": deploy_content["constructor_calldata"],
+            "contract_address_salt": salt,
+            "constructor_calldata": calldata,
             "contract_definition": rpc_contract,
         }
     )

--- a/test/rpc/test_rpc_transactions.py
+++ b/test/rpc/test_rpc_transactions.py
@@ -390,7 +390,7 @@ def test_add_declare_transaction(declare_content):
         "starknet_addDeclareTransaction",
         params={
             "contract_class": rpc_contract,
-            "version": constants.TRANSACTION_VERSION,
+            "version": hex(constants.TRANSACTION_VERSION),
         }
     )
     receipt = resp["result"]

--- a/test/rpc/test_rpc_transactions.py
+++ b/test/rpc/test_rpc_transactions.py
@@ -329,16 +329,14 @@ def test_add_invoke_transaction(invoke_content):
     """
     Add invoke transaction
     """
-    function_invocation = RpcInvokeTransaction(
-        contract_address=invoke_content["contract_address"],
-        entry_point_selector=invoke_content["entry_point_selector"],
-        calldata=invoke_content["calldata"],
-    )
-
     resp = rpc_call(
         "starknet_addInvokeTransaction",
         params={
-            "function_invocation": function_invocation,
+            "function_invocation": {
+                "contract_address": invoke_content["contract_address"],
+                "entry_point_selector": invoke_content["entry_point_selector"],
+                "calldata": invoke_content["calldata"],
+            },
             "signature": invoke_content["signature"],
             "max_fee": hex(0),
             "version": hex(constants.TRANSACTION_VERSION),
@@ -346,7 +344,7 @@ def test_add_invoke_transaction(invoke_content):
     )
     receipt = resp["result"]
 
-    assert set(receipt.keys()) == set(["transaction_hash"])
+    assert set(receipt.keys()) == {"transaction_hash"}
     assert receipt["transaction_hash"][:3] == "0x0"
 
 

--- a/test/rpc/test_rpc_transactions.py
+++ b/test/rpc/test_rpc_transactions.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import List
 
 from starkware.starknet.definitions import constants
-from starknet_devnet.blueprints.rpc import RpcContractClass, RpcInvokeTransaction
+from starknet_devnet.blueprints.rpc import RpcContractClass
 
 from .rpc_utils import rpc_call, get_block_with_transaction, pad_zero
 


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

- Add type cast to rpc declare transaction `version` parameter. [RPC spec specifies ](https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_write_api.json#L75)that the `version` should be be a number represented as hex value, however current rpc implementation doesn't include required casts.
- Add type cast to rpc deploy calldata and salt parameters.

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

- Removed incomplete typeddict call from `add_invoke_transaction` test.

## Checklist:

- [x] No linter errors
- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
