### PR TITLE
Fix get_trace for declare transactions

### DIFF
--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -203,7 +203,7 @@ class StarknetWrapper:
         transaction = DevnetTransaction(
             internal_tx=internal_declare,
             status=TransactionStatus.ACCEPTED_ON_L2,
-            execution_info=DummyExecutionInfo(0, declare_transaction.sender_address, internal_declare.class_hash),
+            execution_info=DummyExecutionInfo(),
             transaction_hash=tx_hash
         )
 
@@ -254,7 +254,7 @@ class StarknetWrapper:
         except StarkException as err:
             error_message = err.message
             status = TransactionStatus.REJECTED
-            execution_info = DummyExecutionInfo(contract_address, 0, None)
+            execution_info = DummyExecutionInfo()
             state_update = None
 
         transaction = DevnetTransaction(
@@ -295,7 +295,7 @@ class StarknetWrapper:
         except StarkException as err:
             error_message = err.message
             status = TransactionStatus.REJECTED
-            execution_info = DummyExecutionInfo(invoke_transaction.contract_address, invoke_transaction.caller_address, None)
+            execution_info = DummyExecutionInfo()
             adapted_result = []
             state_update = None
 

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -203,7 +203,7 @@ class StarknetWrapper:
         transaction = DevnetTransaction(
             internal_tx=internal_declare,
             status=TransactionStatus.ACCEPTED_ON_L2,
-            execution_info=DummyExecutionInfo(),
+            execution_info=DummyExecutionInfo(0, declare_transaction.sender_address, internal_declare.class_hash),
             transaction_hash=tx_hash
         )
 
@@ -254,7 +254,7 @@ class StarknetWrapper:
         except StarkException as err:
             error_message = err.message
             status = TransactionStatus.REJECTED
-            execution_info = DummyExecutionInfo()
+            execution_info = DummyExecutionInfo(contract_address, 0, None)
             state_update = None
 
         transaction = DevnetTransaction(
@@ -295,7 +295,7 @@ class StarknetWrapper:
         except StarkException as err:
             error_message = err.message
             status = TransactionStatus.REJECTED
-            execution_info = DummyExecutionInfo()
+            execution_info = DummyExecutionInfo(invoke_transaction.contract_address, invoke_transaction.caller_address, None)
             adapted_result = []
             state_update = None
 

--- a/starknet_devnet/transactions.py
+++ b/starknet_devnet/transactions.py
@@ -115,12 +115,18 @@ class DevnetTransaction:
         """Returns the transaction receipt"""
         tx_info = self.get_tx_info()
 
+        execution_resources = (
+            self.execution_info.call_info.execution_resources
+            if not self.status == TransactionStatus.REJECTED
+            else None
+        )
+
         return TransactionReceipt.from_tx_info(
             transaction_hash=self.transaction_hash,
             tx_info=tx_info,
             actual_fee=self.__get_actual_fee(),
             events=self.__get_events(),
-            execution_resources=self.execution_info.call_info.execution_resources,
+            execution_resources=execution_resources,
             l2_to_l1_messages=self.__get_l2_to_l1_messages()
         )
 

--- a/starknet_devnet/util.py
+++ b/starknet_devnet/util.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 import os
 import sys
-from typing import List, Dict, Optional, Union
+from typing import List, Dict, Union
 
 from starkware.starkware_utils.error_handling import StarkException
 from starkware.starknet.testing.contract import StarknetContract
@@ -204,9 +204,9 @@ class StarknetDevnetException(StarkException):
 @dataclass
 class DummyExecutionInfo:
     """Used if tx fails, but execution info is still required."""
-    def __init__(self, contract_address: int, caller_address: int, class_hash: Optional[bytes]):
+    def __init__(self):
         self.actual_fee = 0
-        self.call_info = CallInfo.empty(contract_address, caller_address, class_hash)
+        self.call_info = CallInfo.empty_for_testing()
         self.retdata = []
         self.internal_calls = []
         self.l2_to_l1_messages = []

--- a/starknet_devnet/util.py
+++ b/starknet_devnet/util.py
@@ -7,10 +7,11 @@ from dataclasses import dataclass
 from enum import Enum, auto
 import os
 import sys
-from typing import List, Dict, Union
+from typing import List, Dict, Optional, Union
 
 from starkware.starkware_utils.error_handling import StarkException
 from starkware.starknet.testing.contract import StarknetContract
+from starkware.starknet.business_logic.execution.objects import CallInfo
 from starkware.starknet.business_logic.state.state import CarriedState
 from starkware.starknet.services.api.feeder_gateway.response_objects import (
     BlockStateUpdate, StateDiff, StorageEntry, DeployedContract
@@ -201,20 +202,11 @@ class StarknetDevnetException(StarkException):
         self.status_code = status_code
 
 @dataclass
-class DummyCallInfo:
-    """Used temporarily until contracts received from starknet.deploy include their own execution_info.call_info"""
-    def __init__(self):
-        self.execution_resources = None
-        self.contract_address = None
-        self.events = []
-        self.internal_calls = []
-
-@dataclass
 class DummyExecutionInfo:
-    """Used temporarily until contracts received from starknet.deploy include their own execution_info."""
-    def __init__(self):
+    """Used if tx fails, but execution info is still required."""
+    def __init__(self, contract_address: int, caller_address: int, class_hash: Optional[bytes]):
         self.actual_fee = 0
-        self.call_info = DummyCallInfo()
+        self.call_info = CallInfo.empty(contract_address, caller_address, class_hash)
         self.retdata = []
         self.internal_calls = []
         self.l2_to_l1_messages = []

--- a/test/test_transaction_trace.py
+++ b/test/test_transaction_trace.py
@@ -6,7 +6,7 @@ import pytest
 import requests
 from starkware.starknet.services.api.feeder_gateway.response_objects import BlockTransactionTraces
 
-from .util import deploy, get_transaction_receipt, invoke, load_json_from_path, devnet_in_background
+from .util import declare, deploy, get_transaction_receipt, invoke, load_json_from_path, devnet_in_background
 from .settings import APP_URL
 from .shared import ABI_PATH, CONTRACT_PATH, SIGNATURE, NONEXISTENT_TX_HASH, GENESIS_BLOCK_NUMBER
 
@@ -124,3 +124,11 @@ def test_get_block_traces():
     assert_get_block_traces_response({ "blockHash": block_hash }, tx_hash)
     assert_get_block_traces_response({ "blockNumber": GENESIS_BLOCK_NUMBER + 1 }, tx_hash)
     assert_get_block_traces_response({}, tx_hash) # default behavior - no params provided
+
+@pytest.mark.transaction_trace
+@devnet_in_background()
+def test_get_block_traces_after_declare():
+    """Test getting all traces of a block"""
+
+    declare_dict = declare(CONTRACT_PATH)
+    assert_get_block_traces_response({}, declare_dict["tx_hash"])

--- a/test/test_transaction_trace.py
+++ b/test/test_transaction_trace.py
@@ -127,8 +127,15 @@ def test_get_block_traces():
 
 @pytest.mark.transaction_trace
 @devnet_in_background()
-def test_get_block_traces_after_declare():
+def test_get_trace_and_block_traces_after_declare():
     """Test getting all traces of a block"""
 
     declare_dict = declare(CONTRACT_PATH)
+
+    # assert trace
+    trace_response = get_transaction_trace_response(declare_dict["tx_hash"])
+    trace = trace_response.json()
+    assert "function_invocation" in trace
+    assert trace["signature"] == []
+
     assert_get_block_traces_response({}, declare_dict["tx_hash"])


### PR DESCRIPTION
## Usage related changes

- Fix get_trace for declare transactions
- Closes #194 

## Development related changes

- Supersedes #199
- Replace `DummyCallInfo` with `CallInfo.empty_for_testing`

## Checklist:

- [x] No linter errors
- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
- [x] Expand testing to test get_trace (not just get_block_traces)
