### PR TITLE
Fix block number in block info

### DIFF
--- a/starknet_devnet/block_info_generator.py
+++ b/starknet_devnet/block_info_generator.py
@@ -34,7 +34,7 @@ class BlockInfoGenerator():
 
         return BlockInfo(
             gas_price=self.gas_price,
-            block_number=block_info.block_number,
+            block_number=block_info.block_number + 1,
             block_timestamp=block_timestamp,
             sequencer_address=general_config.sequencer_address,
             starknet_version=CAIRO_LANG_VERSION

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -192,7 +192,7 @@ class StarknetWrapper:
 
         internal_declare: InternalDeclare = InternalDeclare.from_external(
             declare_transaction,
-            self.starknet.state.general_config
+            self.get_state().general_config
         )
         declared_class = await self.starknet.declare(
             contract_class=declare_transaction.contract_class,

--- a/test/contracts/cairo/block_number.cairo
+++ b/test/contracts/cairo/block_number.cairo
@@ -1,0 +1,14 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_block_number
+
+@view
+func my_get_block_number{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }() -> (ts: felt):
+    let (ts) = get_block_number()
+    return (ts)
+end

--- a/test/test_block_number.py
+++ b/test/test_block_number.py
@@ -1,0 +1,39 @@
+"""
+Test block number
+"""
+
+from .shared import ARTIFACTS_PATH, GENESIS_BLOCK_NUMBER
+from .util import create_empty_block, devnet_in_background, deploy, call
+
+BLOCK_NUMBER_CONTRACT_PATH = f"{ARTIFACTS_PATH}/block_number.cairo/block_number.json"
+BLOCK_NUMBER_ABI_PATH = f"{ARTIFACTS_PATH}/block_number.cairo/block_number_abi.json"
+
+def my_get_block_number(address: str):
+    """Execute my_get_block_number on block_number.cairo contract deployed at `address`"""
+    return call(
+        function="my_get_block_number",
+        address=address,
+        abi_path=BLOCK_NUMBER_ABI_PATH
+    )
+
+def base_workflow():
+    """Used by test cases to perform the test"""
+    deploy_info = deploy(BLOCK_NUMBER_CONTRACT_PATH)
+    block_number_before = my_get_block_number(deploy_info["address"])
+    assert int(block_number_before) == GENESIS_BLOCK_NUMBER + 1
+
+    # generate a new block
+    create_empty_block()
+
+    block_number_after = my_get_block_number(deploy_info["address"])
+    assert int(block_number_after) == GENESIS_BLOCK_NUMBER + 2
+
+@devnet_in_background()
+def test_block_number_incremented():
+    """Tests how block number is incremented with"""
+    base_workflow()
+
+@devnet_in_background("--lite-mode")
+def test_block_number__incremented_in_lite_mode():
+    """Tests compatibility with lite mode"""
+    base_workflow()

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -8,7 +8,7 @@ import pytest
 
 from starknet_devnet.server import app
 from starknet_devnet.constants import DEFAULT_GAS_PRICE
-from .util import devnet_in_background, load_file_content, deploy
+from .util import create_empty_block, devnet_in_background, load_file_content, deploy
 from .support.assertions import assert_valid_schema
 from .settings import APP_URL
 from .shared import GENESIS_BLOCK_HASH, GENESIS_BLOCK_NUMBER, STORAGE_CONTRACT_PATH
@@ -265,7 +265,7 @@ def test_create_block_endpoint():
     assert resp.get("block_hash") == GENESIS_BLOCK_HASH
     assert resp.get("block_number") == GENESIS_BLOCK_NUMBER
 
-    resp = requests.post(f"{APP_URL}/create_block").json()
+    resp = create_empty_block()
     assert resp.get("block_number") == GENESIS_BLOCK_NUMBER + 1
     assert resp.get("block_hash") == hex(GENESIS_BLOCK_NUMBER + 1)
     assert resp.get("status") == "ACCEPTED_ON_L2"
@@ -276,7 +276,7 @@ def test_create_block_endpoint():
     resp = get_block_by_number({"blockNumber": "latest"}).json()
     assert resp.get("block_number") == GENESIS_BLOCK_NUMBER + 2
 
-    resp = requests.post(f"{APP_URL}/create_block").json()
+    resp = create_empty_block()
     assert resp.get("block_number") == GENESIS_BLOCK_NUMBER + 3
     assert resp.get("block_hash") == hex(GENESIS_BLOCK_NUMBER + 3)
 

--- a/test/util.py
+++ b/test/util.py
@@ -412,3 +412,9 @@ def load_file_content(file_name: str):
     full_file_path = os.path.join(os.path.dirname(__file__), file_name)
     with open(full_file_path, encoding="utf-8") as deploy_file:
         return deploy_file.read()
+
+def create_empty_block():
+    """Creates an empty block and returns it."""
+    resp = requests.post(f"{APP_URL}/create_block")
+    assert resp.status_code == 200
+    return resp.json()


### PR DESCRIPTION
## Usage related changes

- Fix result of `get_block_number` cairo syscall.
  - Fix #210

## Development related changes

- Change the remaining occurrences of direct usage of self.starknet.state in starknet_wrapper (remainder from #189).
- Introduce a utility function for creating an empty block in tests.

## Checklist:

- [x] No linter errors
- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
