### PR TITLE
Enable shopt globstar in CI/CD to run tests in subdirectories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,12 @@ jobs:
           parallel: true
           command: |
             mkdir -p test-results
-            SPLITED_FILES_CLASS=$(circleci tests glob test/test*.py | sed  "s/\.py//g; s/\//./g" | circleci tests split --split-by=timings --timings-type=classname)
+            shopt -s globstar
+            SPLITED_FILES_CLASS=$(
+              circleci tests glob test/**/test*.py |
+              sed  "s/\.py//g; s/\//./g" |
+              circleci tests split --split-by=timings --timings-type=classname
+            )
             TEST_FILES=$(sed "s/\./\//g; s/ /.py /g; s/$/.py/g;" \<<< $SPLITED_FILES_CLASS)
             poetry run pytest -s -v --junitxml=test-results/junit.xml $TEST_FILES
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,12 @@ jobs:
           command: |
             mkdir -p test-results
             shopt -s globstar
-            SPLITED_FILES_CLASS=$(
+            SPLIT_BY_CLASS=$(
               circleci tests glob test/**/test*.py |
               sed  "s/\.py//g; s/\//./g" |
               circleci tests split --split-by=timings --timings-type=classname
             )
-            TEST_FILES=$(sed "s/\./\//g; s/ /.py /g; s/$/.py/g;" \<<< $SPLITED_FILES_CLASS)
+            TEST_FILES=$(sed "s/\./\//g; s/ /.py /g; s/$/.py/g;" \<<< $SPLIT_BY_CLASS)
             poetry run pytest -s -v --junitxml=test-results/junit.xml $TEST_FILES
       - store_test_results:
           path: test-results


### PR DESCRIPTION
## Usage related changes

None

## Development related changes

- Enable running of tests in nested directories (so far rpc tests were not run for this reason).
- Improved readability of test splitting.

## Checklist:

- [x] No linter errors
- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Updated the tests
- [x] All tests are passing
