### PR TITLE
Isolate devnet config, move parsing, dump synchronously

### DIFF
--- a/starknet_devnet/accounts.py
+++ b/starknet_devnet/accounts.py
@@ -8,15 +8,24 @@ import sys
 from typing import List
 from starkware.crypto.signature.signature import private_to_stark_key
 from .account import Account
+from .devnet_config import devnet_config
 
 class Accounts:
     """Accounts wrapper"""
-    list: List[Account] = []
+    list: List[Account]
 
     def __init__(self, starknet_wrapper):
         self.starknet_wrapper = starknet_wrapper
         self.__initial_balance = None
         self.__seed = None
+        self.list = []
+
+        self.__generate(
+            n_accounts=devnet_config.accounts,
+            initial_balance=devnet_config.initial_balance,
+            seed=devnet_config.seed
+        )
+        self.__print()
 
     def __getitem__(self, index):
         return self.list[index]
@@ -31,7 +40,7 @@ class Accounts:
         self.list.append(account)
         return account
 
-    def generate(self, n_accounts: int, initial_balance: int, seed: int):
+    def __generate(self, n_accounts: int, initial_balance: int, seed: int):
         """Generates accounts without deploying them"""
         random_generator = random.Random()
         self.__initial_balance = initial_balance
@@ -52,7 +61,7 @@ class Accounts:
                 initial_balance=initial_balance
             ))
 
-    def print(self):
+    def __print(self):
         """stdout accounts list"""
         for idx, account in enumerate(self):
             print(f"Account #{idx}")

--- a/starknet_devnet/accounts.py
+++ b/starknet_devnet/accounts.py
@@ -8,7 +8,6 @@ import sys
 from typing import List
 from starkware.crypto.signature.signature import private_to_stark_key
 from .account import Account
-from .devnet_config import devnet_config
 
 class Accounts:
     """Accounts wrapper"""
@@ -21,11 +20,12 @@ class Accounts:
         self.list = []
 
         self.__generate(
-            n_accounts=devnet_config.accounts,
-            initial_balance=devnet_config.initial_balance,
-            seed=devnet_config.seed
+            n_accounts=starknet_wrapper.config.accounts,
+            initial_balance=starknet_wrapper.config.initial_balance,
+            seed=starknet_wrapper.config.seed
         )
-        self.__print()
+        if starknet_wrapper.config.accounts:
+            self.__print()
 
     def __getitem__(self, index):
         return self.list[index]

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -1,7 +1,6 @@
 """
 Base routes
 """
-from pickle import UnpicklingError
 from flask import Blueprint, Response, request, jsonify
 from starknet_devnet.fee_token import FeeToken
 
@@ -79,14 +78,7 @@ def load():
     if not load_path:
         raise StarknetDevnetException(message="No path provided.", status_code=400)
 
-    try:
-        state.load(load_path)
-    except (FileNotFoundError, UnpicklingError) as error:
-        raise StarknetDevnetException(
-            message=f"Error: Cannot load from {load_path}. Make sure the file exists and contains a Devnet dump.",
-            status_code=400
-        ) from error
-
+    state.load(load_path)
     return Response(status=200)
 
 @base.route("/increase_time", methods=["POST"])

--- a/starknet_devnet/blueprints/gateway.py
+++ b/starknet_devnet/blueprints/gateway.py
@@ -5,7 +5,8 @@ from flask import Blueprint, request, jsonify
 from starkware.starknet.definitions.transaction_type import TransactionType
 from starkware.starkware_utils.error_handling import StarkErrorCode
 
-from starknet_devnet.util import DumpOn, StarknetDevnetException,fixed_length_hex
+from starknet_devnet.devnet_config import DumpOn
+from starknet_devnet.util import StarknetDevnetException,fixed_length_hex
 from starknet_devnet.state import state
 from .shared import validate_transaction
 

--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -1,0 +1,171 @@
+"""Module for configuration specified by user"""
+
+import argparse
+from enum import Enum, auto
+import sys
+
+from . import __version__
+from .constants import (
+    DEFAULT_ACCOUNTS,
+    DEFAULT_GAS_PRICE,
+    DEFAULT_HOST,
+    DEFAULT_INITIAL_BALANCE,
+    DEFAULT_PORT
+)
+
+
+# Uncomment this once fork support is added
+# def _fork_url(name: str):
+#     """
+#     Return the URL corresponding to the provided name.
+#     If it's not one of predefined names, assumes it is already a URL.
+#     """
+#     if name in ["alpha", "alpha-goerli"]:
+#         return "https://alpha4.starknet.io"
+#     if name == "alpha-mainnet":
+#         return "https://alpha-mainnet.starknet.io"
+#     # otherwise a URL; perhaps check validity
+#     return name
+
+class DumpOn(Enum):
+    """Enumerate possible dumping frequencies."""
+    EXIT = auto()
+    TRANSACTION = auto()
+
+DUMP_ON_OPTIONS = [e.name.lower() for e in DumpOn]
+DUMP_ON_OPTIONS_STRINGIFIED = ", ".join(DUMP_ON_OPTIONS)
+
+def parse_dump_on(option: str):
+    """Parse dumping frequency option."""
+    if option in DUMP_ON_OPTIONS:
+        return DumpOn[option.upper()]
+    sys.exit(f"Error: Invalid --dump-on option: {option}. Valid options: {DUMP_ON_OPTIONS_STRINGIFIED}")
+
+class NonNegativeAction(argparse.Action):
+    """
+    Action for parsing the non negative int argument.
+    """
+    def __call__(self, parser, namespace, values, option_string=None):
+        value = int(values)
+
+        if value < 0:
+            parser.error(f"{option_string} must be a positive integer.")
+
+        setattr(namespace, self.dest, value)
+
+def parse_args():
+    """
+    Parses CLI arguments.
+    """
+    parser = argparse.ArgumentParser(description="Run a local instance of Starknet Devnet")
+    parser.add_argument(
+        "-v", "--version",
+        help="Print the version",
+        action="version",
+        version=__version__
+    )
+    parser.add_argument(
+        "--host",
+        help=f"Specify the address to listen at; defaults to {DEFAULT_HOST} " +
+             "(use the address the program outputs on start)",
+        default=DEFAULT_HOST
+    )
+    parser.add_argument(
+        "--port", "-p",
+        type=int,
+        help=f"Specify the port to listen at; defaults to {DEFAULT_PORT}",
+        default=DEFAULT_PORT
+    )
+    parser.add_argument(
+        "--load-path",
+        help="Specify the path from which the state is loaded on startup"
+    )
+    parser.add_argument(
+        "--dump-path",
+        help="Specify the path to dump to"
+    )
+    parser.add_argument(
+        "--dump-on",
+        help=f"Specify when to dump; can dump on: {DUMP_ON_OPTIONS_STRINGIFIED}",
+        type=parse_dump_on
+    )
+    parser.add_argument(
+        "--lite-mode",
+        action="store_true",
+        help="Applies all lite-mode-* optimizations by disabling some features."
+    )
+    parser.add_argument(
+        "--lite-mode-block-hash",
+        action="store_true",
+        help="Disables block hash calculation"
+    )
+    parser.add_argument(
+        "--lite-mode-deploy-hash",
+        action="store_true",
+        help="Disables deploy tx hash calculation"
+    )
+    parser.add_argument(
+        "--accounts",
+        type=int,
+        help=f"Specify the number of accounts to be predeployed; defaults to {DEFAULT_ACCOUNTS}",
+        default=DEFAULT_ACCOUNTS
+    )
+    parser.add_argument(
+        "--initial-balance", "-e",
+        type=int,
+        help="Specify the initial balance of accounts to be predeployed; " +
+             f"defaults to {DEFAULT_INITIAL_BALANCE:g}",
+        default=DEFAULT_INITIAL_BALANCE
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help="Specify the seed for randomness of accounts to be predeployed"
+    )
+    parser.add_argument(
+        "--start-time",
+        action=NonNegativeAction,
+        help="Specify the start time of the genesis block in Unix time seconds"
+    )
+    parser.add_argument(
+        "--gas-price", "-g",
+        action=NonNegativeAction,
+        default=DEFAULT_GAS_PRICE,
+        help="Specify the gas price in wei per gas unit; " +
+             f"defaults to {DEFAULT_GAS_PRICE:g}"
+    )
+    # Uncomment this once fork support is added
+    # parser.add_argument(
+    #     "--fork", "-f",
+    #     type=_fork_url,
+    #     help="Specify the network to fork: can be a URL (e.g. https://alpha-mainnet.starknet.io) " +
+    #          "or network name (alpha or alpha-mainnet)",
+    # )
+
+    args = parser.parse_args()
+    if args.dump_on and not args.dump_path:
+        sys.exit("Error: --dump-path required if --dump-on present")
+
+    return args
+
+# pylint: disable=too-few-public-methods
+# pylint: disable=too-many-instance-attributes
+class DevnetConfig:
+    """Class holding configuration specified by user"""
+
+    def __init__(self, args: argparse.Namespace=None):
+        self.args = args
+        self.accounts = args.accounts
+        self.initial_balance = args.initial_balance
+        self.seed = args.seed
+        self.start_time = args.start_time
+        self.gas_price = args.gas_price
+
+        if args.lite_mode:
+            self.lite_mode_block_hash = True
+            self.lite_mode_deploy_hash = True
+        else:
+            self.lite_mode_block_hash = args.lite_mode_block_hash
+            self.lite_mode_deploy_hash = args.lite_mode_deploy_hash
+
+devnet_config = DevnetConfig(parse_args())

--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -3,6 +3,7 @@
 import argparse
 from enum import Enum, auto
 import sys
+from typing import List
 
 from . import __version__
 from .constants import (
@@ -53,7 +54,7 @@ class NonNegativeAction(argparse.Action):
 
         setattr(namespace, self.dest, value)
 
-def parse_args():
+def parse_args(raw_args: List[str]):
     """
     Parses CLI arguments.
     """
@@ -142,11 +143,11 @@ def parse_args():
     #          "or network name (alpha or alpha-mainnet)",
     # )
 
-    args = parser.parse_args()
-    if args.dump_on and not args.dump_path:
+    parsed_args = parser.parse_args(raw_args)
+    if parsed_args.dump_on and not parsed_args.dump_path:
         sys.exit("Error: --dump-path required if --dump-on present")
 
-    return args
+    return parsed_args
 
 # pylint: disable=too-few-public-methods
 # pylint: disable=too-many-instance-attributes
@@ -154,18 +155,16 @@ class DevnetConfig:
     """Class holding configuration specified by user"""
 
     def __init__(self, args: argparse.Namespace=None):
-        self.args = args
-        self.accounts = args.accounts
-        self.initial_balance = args.initial_balance
-        self.seed = args.seed
-        self.start_time = args.start_time
-        self.gas_price = args.gas_price
+        self.args = args or parse_args(["--accounts", "0"])
+        self.accounts = self.args.accounts
+        self.initial_balance = self.args.initial_balance
+        self.seed = self.args.seed
+        self.start_time = self.args.start_time
+        self.gas_price = self.args.gas_price
 
-        if args.lite_mode:
+        if self.args.lite_mode:
             self.lite_mode_block_hash = True
             self.lite_mode_deploy_hash = True
         else:
-            self.lite_mode_block_hash = args.lite_mode_block_hash
-            self.lite_mode_deploy_hash = args.lite_mode_deploy_hash
-
-devnet_config = DevnetConfig(parse_args())
+            self.lite_mode_block_hash = self.args.lite_mode_block_hash
+            self.lite_mode_deploy_hash = self.args.lite_mode_deploy_hash

--- a/starknet_devnet/dump.py
+++ b/starknet_devnet/dump.py
@@ -4,7 +4,7 @@ import multiprocessing
 
 import cloudpickle as pickle
 
-from .util import DumpOn
+from .devnet_config import DumpOn
 
 # Instead of "fork", the default on MacOS since Python3.8 has been "spawn", which causes pickling to fail
 multiprocessing.set_start_method("fork")
@@ -32,10 +32,6 @@ class Dumper:
         """Dump to `path`."""
         path = path or self.dump_path
         assert path, "No dump_path defined"
-        print("Dumping Devnet to:", path)
 
-        multiprocessing.Process(
-            target=self.__write_file,
-            args=[path]
-        ).start()
-        # don't .join(), let it run in background
+        print("Dumping Devnet to:", path)
+        self.__write_file(path)

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -2,7 +2,6 @@
 A server exposing Starknet functionalities as API endpoints.
 """
 
-from pickle import UnpicklingError
 import sys
 import asyncio
 
@@ -11,6 +10,8 @@ from flask_cors import CORS
 from gunicorn.app.base import BaseApplication
 from starkware.starkware_utils.error_handling import StarkException
 
+from .util import StarknetDevnetException
+
 from .starknet_wrapper import StarknetWrapper
 
 from .blueprints.base import base
@@ -18,7 +19,6 @@ from .blueprints.gateway import gateway
 from .blueprints.feeder_gateway import feeder_gateway
 from .blueprints.postman import postman
 from .blueprints.rpc import rpc
-from .util import check_valid_dump_path
 from .state import state
 from .devnet_config import DevnetConfig, DumpOn, parse_args
 
@@ -37,28 +37,9 @@ app.register_blueprint(feeder_gateway)
 app.register_blueprint(postman)
 app.register_blueprint(rpc)
 
-def set_dump_options(args):
-    """Assign dumping options from args to state."""
-    if args.dump_path:
-        try:
-            check_valid_dump_path(args.dump_path)
-        except ValueError as error:
-            sys.exit(str(error))
-
-    state.dumper.dump_path = args.dump_path
-    state.dumper.dump_on = args.dump_on
-
-def load_dumped(args):
-    """Load a previously dumped state if specified."""
-    if args.load_path:
-        try:
-            state.load(args.load_path)
-        except (FileNotFoundError, UnpicklingError):
-            sys.exit(f"Error: Cannot load from {args.load_path}. Make sure the file exists and contains a Devnet dump.")
-
 # We don't need init method here.
 # pylint: disable=W0223
-class Devnet(BaseApplication):
+class GunicornServer(BaseApplication):
     """Our Gunicorn application."""
 
     def __init__(self, application, args):
@@ -100,15 +81,21 @@ def main():
     # starknet_wrapper.origin = origin
 
     args = parse_args(sys.argv[1:])
-    state.set_starknet_wrapper(StarknetWrapper(DevnetConfig(args)))
-    load_dumped(args)
-    set_dump_options(args)
+    try:
+        if args.load_path:
+            state.load(args.load_path)
+        else:
+            state.set_starknet_wrapper(StarknetWrapper(DevnetConfig(args)))
+
+        state.set_dump_options(args.dump_path, args.dump_on)
+    except StarknetDevnetException as error:
+        sys.exit(error.message)
 
     asyncio.run(state.starknet_wrapper.initialize())
 
     try:
         print(f" * Listening on http://{args.host}:{args.port}/ (Press CTRL+C to quit)")
-        Devnet(app, args).run()
+        GunicornServer(app, args).run()
     except KeyboardInterrupt:
         pass
     finally:

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -11,6 +11,8 @@ from flask_cors import CORS
 from gunicorn.app.base import BaseApplication
 from starkware.starkware_utils.error_handling import StarkException
 
+from .starknet_wrapper import StarknetWrapper
+
 from .blueprints.base import base
 from .blueprints.gateway import gateway
 from .blueprints.feeder_gateway import feeder_gateway
@@ -18,11 +20,12 @@ from .blueprints.postman import postman
 from .blueprints.rpc import rpc
 from .util import check_valid_dump_path
 from .state import state
-from .devnet_config import devnet_config, DumpOn
+from .devnet_config import DevnetConfig, DumpOn, parse_args
 
 app = Flask(__name__)
 CORS(app)
 
+# if this is removed, the tests which don't run the main function will fail
 @app.before_first_request
 async def initialize_starknet():
     """Initialize Starknet to assert it's defined before its first use."""
@@ -89,7 +92,6 @@ class Devnet(BaseApplication):
     def load(self):
         return self.application
 
-
 def main():
     """Runs the server."""
 
@@ -97,7 +99,8 @@ def main():
     # origin = Origin(args.fork) if args.fork else NullOrigin()
     # starknet_wrapper.origin = origin
 
-    args = devnet_config.args
+    args = parse_args(sys.argv[1:])
+    state.set_starknet_wrapper(StarknetWrapper(DevnetConfig(args)))
     load_dumped(args)
     set_dump_options(args)
 

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -16,9 +16,9 @@ from .blueprints.gateway import gateway
 from .blueprints.feeder_gateway import feeder_gateway
 from .blueprints.postman import postman
 from .blueprints.rpc import rpc
-from .util import DumpOn, check_valid_dump_path, parse_args
-from .starknet_wrapper import DevnetConfig
+from .util import check_valid_dump_path
 from .state import state
+from .devnet_config import devnet_config, DumpOn
 
 app = Flask(__name__)
 CORS(app)
@@ -33,16 +33,6 @@ app.register_blueprint(gateway)
 app.register_blueprint(feeder_gateway)
 app.register_blueprint(postman)
 app.register_blueprint(rpc)
-
-def generate_accounts(args):
-    """Generate accounts """
-    if args.accounts:
-        state.starknet_wrapper.accounts.generate(
-            n_accounts=args.accounts,
-            initial_balance=args.initial_balance,
-            seed=args.seed
-        )
-        state.starknet_wrapper.accounts.print()
 
 def set_dump_options(args):
     """Assign dumping options from args to state."""
@@ -62,30 +52,6 @@ def load_dumped(args):
             state.load(args.load_path)
         except (FileNotFoundError, UnpicklingError):
             sys.exit(f"Error: Cannot load from {args.load_path}. Make sure the file exists and contains a Devnet dump.")
-
-def enable_lite_mode(args):
-    """Enable lite mode if specified."""
-    if args.lite_mode:
-        config = DevnetConfig(
-            lite_mode_block_hash=True,
-            lite_mode_deploy_hash=True
-        )
-    else:
-        config = DevnetConfig(
-            lite_mode_block_hash=args.lite_mode_block_hash,
-            lite_mode_deploy_hash=args.lite_mode_deploy_hash
-        )
-
-    state.starknet_wrapper.set_config(config)
-
-def set_start_time(args):
-    """Assign start time if specified."""
-    if args.start_time is not None:
-        state.starknet_wrapper.set_block_time(args.start_time)
-
-def set_gas_price(args):
-    """Assign gas_price"""
-    state.starknet_wrapper.set_gas_price(args.gas_price)
 
 # We don't need init method here.
 # pylint: disable=W0223
@@ -127,18 +93,13 @@ class Devnet(BaseApplication):
 def main():
     """Runs the server."""
 
-    args = parse_args()
-
     # Uncomment this once fork support is added
     # origin = Origin(args.fork) if args.fork else NullOrigin()
     # starknet_wrapper.origin = origin
 
+    args = devnet_config.args
     load_dumped(args)
     set_dump_options(args)
-    generate_accounts(args)
-    enable_lite_mode(args)
-    set_start_time(args)
-    set_gas_price(args)
 
     asyncio.run(state.starknet_wrapper.initialize())
 

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -2,7 +2,6 @@
 This module introduces `StarknetWrapper`, a wrapper class of
 starkware.starknet.testing.starknet.Starknet.
 """
-import dataclasses
 from copy import deepcopy
 from typing import Dict, List, Tuple, Union
 
@@ -39,14 +38,9 @@ from .transactions import DevnetTransactions, DevnetTransaction
 from .contracts import DevnetContracts
 from .blocks import DevnetBlocks
 from .block_info_generator import BlockInfoGenerator
+from .devnet_config import DevnetConfig
 
 enable_pickling()
-
-@dataclasses.dataclass
-class DevnetConfig:
-    """Configuration for the devnet."""
-    lite_mode_block_hash: bool = False
-    lite_mode_deploy_hash: bool = False
 
 #pylint: disable=too-many-instance-attributes
 class StarknetWrapper:
@@ -70,6 +64,11 @@ class StarknetWrapper:
         self.__initialized = False
         self.fee_token = FeeToken(self)
         self.accounts = Accounts(self)
+
+        if config.start_time is not None:
+            self.set_block_time(config.start_time)
+
+        self.set_gas_price(config.gas_price)
 
     @staticmethod
     def load(path: str) -> "StarknetWrapper":

--- a/starknet_devnet/state.py
+++ b/starknet_devnet/state.py
@@ -2,23 +2,23 @@
 Global state singletone
 """
 
+from .devnet_config import DevnetConfig, devnet_config
 from .dump import Dumper
-from .starknet_wrapper import StarknetWrapper, DevnetConfig
+from .starknet_wrapper import StarknetWrapper
 
 class State():
     """
     Stores starknet wrapper and dumper
     """
     def __init__(self):
-        self.starknet_wrapper = StarknetWrapper(config=DevnetConfig())
-        self.dumper = Dumper(self.starknet_wrapper)
+        self.__set_starknet_wrapper(StarknetWrapper(config=devnet_config))
 
     def __set_starknet_wrapper(self, starknet_wrapper: StarknetWrapper):
         """Sets starknet wrapper and creates new instance of dumper"""
         self.starknet_wrapper = starknet_wrapper
         self.dumper = Dumper(starknet_wrapper)
 
-    async def reset(self, config: DevnetConfig = None):
+    async def reset(self, config: DevnetConfig=None):
         """Reset the starknet wrapper and dumper instances"""
         previous_config = self.starknet_wrapper.config
         self.__set_starknet_wrapper(StarknetWrapper(config=config or previous_config))

--- a/starknet_devnet/state.py
+++ b/starknet_devnet/state.py
@@ -2,7 +2,7 @@
 Global state singletone
 """
 
-from .devnet_config import DevnetConfig, devnet_config
+from .devnet_config import DevnetConfig
 from .dump import Dumper
 from .starknet_wrapper import StarknetWrapper
 
@@ -11,21 +11,21 @@ class State():
     Stores starknet wrapper and dumper
     """
     def __init__(self):
-        self.__set_starknet_wrapper(StarknetWrapper(config=devnet_config))
+        self.set_starknet_wrapper(StarknetWrapper(DevnetConfig()))
 
-    def __set_starknet_wrapper(self, starknet_wrapper: StarknetWrapper):
+    def set_starknet_wrapper(self, starknet_wrapper: StarknetWrapper):
         """Sets starknet wrapper and creates new instance of dumper"""
         self.starknet_wrapper = starknet_wrapper
         self.dumper = Dumper(starknet_wrapper)
 
-    async def reset(self, config: DevnetConfig=None):
+    async def reset(self):
         """Reset the starknet wrapper and dumper instances"""
         previous_config = self.starknet_wrapper.config
-        self.__set_starknet_wrapper(StarknetWrapper(config=config or previous_config))
+        self.set_starknet_wrapper(StarknetWrapper(previous_config))
         await self.starknet_wrapper.initialize()
 
     def load(self, load_path: str):
         """Loads starknet wrapper from path"""
-        self.__set_starknet_wrapper(StarknetWrapper.load(load_path))
+        self.set_starknet_wrapper(StarknetWrapper.load(load_path))
 
 state = State()

--- a/starknet_devnet/state.py
+++ b/starknet_devnet/state.py
@@ -2,9 +2,11 @@
 Global state singletone
 """
 
+from pickle import UnpicklingError
 from .devnet_config import DevnetConfig
 from .dump import Dumper
 from .starknet_wrapper import StarknetWrapper
+from .util import StarknetDevnetException, check_valid_dump_path
 
 class State():
     """
@@ -25,7 +27,22 @@ class State():
         await self.starknet_wrapper.initialize()
 
     def load(self, load_path: str):
-        """Loads starknet wrapper from path"""
-        self.set_starknet_wrapper(StarknetWrapper.load(load_path))
+        """Load a previously dumped state if specified."""
+        try:
+            self.set_starknet_wrapper(StarknetWrapper.load(load_path))
+        except (FileNotFoundError, UnpicklingError) as error:
+            message = f"Error: Cannot load from {load_path}. Make sure the file exists and contains a Devnet dump."
+            raise StarknetDevnetException(message=message, status_code=400) from error
+
+    def set_dump_options(self, dump_path: str, dump_on: str):
+        """Assign dumping options from args to state."""
+        if dump_path:
+            try:
+                check_valid_dump_path(dump_path)
+            except ValueError as error:
+                raise StarknetDevnetException(message=str(error)) from error
+
+        self.dumper.dump_path = dump_path
+        self.dumper.dump_on = dump_on
 
 state = State()

--- a/starknet_devnet/util.py
+++ b/starknet_devnet/util.py
@@ -2,11 +2,8 @@
 Utility functions used across the project.
 """
 
-import argparse
 from dataclasses import dataclass
-from enum import Enum, auto
 import os
-import sys
 from typing import List, Dict, Union
 
 from starkware.starkware_utils.error_handling import StarkException
@@ -15,15 +12,6 @@ from starkware.starknet.business_logic.execution.objects import CallInfo
 from starkware.starknet.business_logic.state.state import CarriedState
 from starkware.starknet.services.api.feeder_gateway.response_objects import (
     BlockStateUpdate, StateDiff, StorageEntry, DeployedContract
-)
-
-from . import __version__
-from .constants import (
-    DEFAULT_ACCOUNTS,
-    DEFAULT_GAS_PRICE,
-    DEFAULT_HOST,
-    DEFAULT_INITIAL_BALANCE,
-    DEFAULT_PORT
 )
 
 def custom_int(arg: str) -> int:
@@ -57,140 +45,6 @@ class Uint256:
             low=felt & ((1 << 128) - 1),
             high=felt >> 128
         )
-
-# Uncomment this once fork support is added
-# def _fork_url(name: str):
-#     """
-#     Return the URL corresponding to the provided name.
-#     If it's not one of predefined names, assumes it is already a URL.
-#     """
-#     if name in ["alpha", "alpha-goerli"]:
-#         return "https://alpha4.starknet.io"
-#     if name == "alpha-mainnet":
-#         return "https://alpha-mainnet.starknet.io"
-#     # otherwise a URL; perhaps check validity
-#     return name
-
-class DumpOn(Enum):
-    """Enumerate possible dumping frequencies."""
-    EXIT = auto()
-    TRANSACTION = auto()
-
-DUMP_ON_OPTIONS = [e.name.lower() for e in DumpOn]
-DUMP_ON_OPTIONS_STRINGIFIED = ", ".join(DUMP_ON_OPTIONS)
-
-def parse_dump_on(option: str):
-    """Parse dumping frequency option."""
-    if option in DUMP_ON_OPTIONS:
-        return DumpOn[option.upper()]
-    sys.exit(f"Error: Invalid --dump-on option: {option}. Valid options: {DUMP_ON_OPTIONS_STRINGIFIED}")
-
-class NonNegativeAction(argparse.Action):
-    """
-    Action for parsing the non negative int argument.
-    """
-    def __call__(self, parser, namespace, values, option_string=None):
-        value = int(values)
-
-        if value < 0:
-            parser.error(f"{option_string} must be a positive integer.")
-
-        setattr(namespace, self.dest, value)
-
-def parse_args():
-    """
-    Parses CLI arguments.
-    """
-    parser = argparse.ArgumentParser(description="Run a local instance of Starknet Devnet")
-    parser.add_argument(
-        "-v", "--version",
-        help="Print the version",
-        action="version",
-        version=__version__
-    )
-    parser.add_argument(
-        "--host",
-        help=f"Specify the address to listen at; defaults to {DEFAULT_HOST} " +
-             "(use the address the program outputs on start)",
-        default=DEFAULT_HOST
-    )
-    parser.add_argument(
-        "--port", "-p",
-        type=int,
-        help=f"Specify the port to listen at; defaults to {DEFAULT_PORT}",
-        default=DEFAULT_PORT
-    )
-    parser.add_argument(
-        "--load-path",
-        help="Specify the path from which the state is loaded on startup"
-    )
-    parser.add_argument(
-        "--dump-path",
-        help="Specify the path to dump to"
-    )
-    parser.add_argument(
-        "--dump-on",
-        help=f"Specify when to dump; can dump on: {DUMP_ON_OPTIONS_STRINGIFIED}",
-        type=parse_dump_on
-    )
-    parser.add_argument(
-        "--lite-mode",
-        action="store_true",
-        help="Applies all lite-mode-* optimizations by disabling some features."
-    )
-    parser.add_argument(
-        "--lite-mode-block-hash",
-        action="store_true",
-        help="Disables block hash calculation"
-    )
-    parser.add_argument(
-        "--lite-mode-deploy-hash",
-        action="store_true",
-        help="Disables deploy tx hash calculation"
-    )
-    parser.add_argument(
-        "--accounts",
-        type=int,
-        help=f"Specify the number of accounts to be predeployed; defaults to {DEFAULT_ACCOUNTS}",
-        default=DEFAULT_ACCOUNTS
-    )
-    parser.add_argument(
-        "--initial-balance", "-e",
-        type=int,
-        help="Specify the initial balance of accounts to be predeployed; " +
-             f"defaults to {DEFAULT_INITIAL_BALANCE:g}",
-        default=DEFAULT_INITIAL_BALANCE
-    )
-    parser.add_argument(
-        "--seed",
-        type=int,
-        help="Specify the seed for randomness of accounts to be predeployed"
-    )
-    parser.add_argument(
-        "--start-time",
-        action=NonNegativeAction,
-        help="Specify the start time of the genesis block in Unix time seconds"
-    )
-    parser.add_argument(
-        "--gas-price", "-g",
-        action=NonNegativeAction,
-        default=DEFAULT_GAS_PRICE,
-        help="Specify the gas price in wei per gas unit; " +
-             f"defaults to {DEFAULT_GAS_PRICE:g}"
-    )
-    # Uncomment this once fork support is added
-    # parser.add_argument(
-    #     "--fork", "-f",
-    #     type=_fork_url,
-    #     help="Specify the network to fork: can be a URL (e.g. https://alpha-mainnet.starknet.io) " +
-    #          "or network name (alpha or alpha-mainnet)",
-    # )
-
-    args = parser.parse_args()
-    if args.dump_on and not args.dump_path:
-        sys.exit("Error: --dump-path required if --dump-on present")
-
-    return args
 
 class StarknetDevnetException(StarkException):
     """

--- a/test/rpc/conftest.py
+++ b/test/rpc/conftest.py
@@ -14,12 +14,22 @@ import pytest
 from starkware.starknet.services.api.contract_class import ContractClass
 from starkware.starknet.services.api.gateway.transaction import Transaction, Deploy
 
-from .rpc_utils import gateway_call
+from .rpc_utils import gateway_call, restart
 
 
 DEPLOY_CONTENT = load_file_content("deploy_rpc.json")
 INVOKE_CONTENT = load_file_content("invoke_rpc.json")
 DECLARE_CONTENT = load_file_content("declare.json")
+
+
+@pytest.fixture(autouse=True)
+def before_and_after():
+    """Fixture that runs before and after each test"""
+    #before test
+
+    yield
+    #after test
+    restart()
 
 
 @pytest.fixture(name="contract_class")
@@ -40,7 +50,7 @@ def fixture_class_hash(deploy_info) -> str:
     return class_hash
 
 
-@pytest.fixture(name="deploy_info", scope="module")
+@pytest.fixture(name="deploy_info", scope="function")
 def fixture_deploy_info() -> dict:
     """
     Deploy a contract on devnet and return deployment info dict
@@ -50,7 +60,7 @@ def fixture_deploy_info() -> dict:
     return deploy_info
 
 
-@pytest.fixture(name="invoke_info", scope="module")
+@pytest.fixture(name="invoke_info", scope="function")
 def fixture_invoke_info() -> dict:
     """
     Make an invoke transaction on devnet and return invoke info dict
@@ -62,7 +72,7 @@ def fixture_invoke_info() -> dict:
     return {**invoke_info, **invoke_tx}
 
 
-@pytest.fixture(name="declare_info", scope="module")
+@pytest.fixture(name="declare_info", scope="function")
 def fixture_declare_info() -> dict:
     """
     Make a declare transaction on devnet and return declare info dict
@@ -73,7 +83,7 @@ def fixture_declare_info() -> dict:
     return {**declare_info, **declare_tx}
 
 
-@pytest.fixture(name="invoke_content", scope="module")
+@pytest.fixture(name="invoke_content", scope="function")
 def fixture_invoke_content() -> dict:
     """
     Invoke content JSON object
@@ -81,7 +91,7 @@ def fixture_invoke_content() -> dict:
     return json.loads(INVOKE_CONTENT)
 
 
-@pytest.fixture(name="deploy_content", scope="module")
+@pytest.fixture(name="deploy_content", scope="function")
 def fixture_deploy_content() -> dict:
     """
     Deploy content JSON object
@@ -89,7 +99,7 @@ def fixture_deploy_content() -> dict:
     return json.loads(DEPLOY_CONTENT)
 
 
-@pytest.fixture(name="declare_content", scope="module")
+@pytest.fixture(name="declare_content", scope="function")
 def fixture_declare_content() -> dict:
     """
     Declare content JSON object

--- a/test/rpc/rpc_utils.py
+++ b/test/rpc/rpc_utils.py
@@ -9,6 +9,11 @@ from typing import Union
 
 from starknet_devnet.server import app
 
+def restart():
+    """Restart app"""
+    resp = app.test_client().post("/restart")
+    assert resp.status_code == 200
+
 
 def rpc_call(method: str, params: Union[dict, list]) -> dict:
     """

--- a/test/test_deploy.py
+++ b/test/test_deploy.py
@@ -1,6 +1,5 @@
 """Test devnet contract deployment"""
 
-from argparse import Namespace
 from typing import List
 import pytest
 
@@ -11,7 +10,8 @@ from starkware.starknet.services.api.contract_class import ContractClass
 from starkware.starknet.services.api.gateway.transaction import Deploy
 from starkware.starknet.services.api.feeder_gateway.response_objects import TransactionStatus
 
-from starknet_devnet.starknet_wrapper import StarknetWrapper, DevnetConfig
+from starknet_devnet.devnet_config import parse_args, DevnetConfig
+from starknet_devnet.starknet_wrapper import StarknetWrapper
 from .shared import CONTRACT_PATH, GENESIS_BLOCK_NUMBER
 
 def get_contract_class():
@@ -35,7 +35,7 @@ async def test_deploy():
     """
     Test the deployment of a contract.
     """
-    devnet = StarknetWrapper(config=DevnetConfig())
+    devnet = StarknetWrapper(config=DevnetConfig(parse_args([])))
     await devnet.initialize()
     deploy_transaction = get_deploy_transaction(inputs=[0])
 
@@ -64,7 +64,7 @@ async def test_deploy_lite():
     """
     Test the deployment of a contract with lite mode.
     """
-    devnet = StarknetWrapper(config=DevnetConfig(Namespace(lite_mode=True)))
+    devnet = StarknetWrapper(config=DevnetConfig(parse_args(["--lite-mode"])))
     await devnet.initialize()
     deploy_transaction = get_deploy_transaction(inputs=[0])
 

--- a/test/test_deploy.py
+++ b/test/test_deploy.py
@@ -1,5 +1,6 @@
 """Test devnet contract deployment"""
 
+from argparse import Namespace
 from typing import List
 import pytest
 
@@ -63,7 +64,7 @@ async def test_deploy_lite():
     """
     Test the deployment of a contract with lite mode.
     """
-    devnet = StarknetWrapper(config=DevnetConfig(lite_mode_block_hash=True, lite_mode_deploy_hash=True))
+    devnet = StarknetWrapper(config=DevnetConfig(Namespace(lite_mode=True)))
     await devnet.initialize()
     deploy_transaction = get_deploy_transaction(inputs=[0])
 

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -108,7 +108,11 @@ def deploy_empty_contract():
 def test_load_via_cli_if_no_file():
     """Test loading via CLI if dump file not present."""
     assert_no_dump_present(DUMP_PATH)
-    devnet_proc = ACTIVE_DEVNET.start("--load-path", DUMP_PATH, stderr=subprocess.PIPE)
+    devnet_proc = ACTIVE_DEVNET.start(
+        "--load-path", DUMP_PATH,
+        "--accounts", "0",
+        stderr=subprocess.PIPE
+    )
     assert devnet_proc.returncode == 1
     expected_msg = f"Error: Cannot load from {DUMP_PATH}. Make sure the file exists and contains a Devnet dump.\n"
     assert expected_msg == devnet_proc.stderr.read().decode("utf-8")
@@ -154,7 +158,11 @@ NONEXISTENT_DIR = "nonexistent-dir"
 def test_dumping_if_nonexistent_dir_via_cli():
     """Assert failure if dumping attempted via cli with a path containing a nonexistent dir"""
     invalid_path = os.path.join(NONEXISTENT_DIR, DUMP_PATH)
-    devnet_proc = ACTIVE_DEVNET.start("--dump-path", invalid_path, stderr=subprocess.PIPE)
+    devnet_proc = ACTIVE_DEVNET.start(
+        "--dump-path", invalid_path,
+        "--accounts", "0",
+        stderr=subprocess.PIPE
+    )
     assert devnet_proc.returncode == 1
 
     expected_msg = f"Invalid dump path: directory '{NONEXISTENT_DIR}' not found.\n"

--- a/test/test_fee_token.py
+++ b/test/test_fee_token.py
@@ -16,13 +16,12 @@ def test_precomputed_address_unchanged():
     assert_equal(FeeToken.ADDRESS, 2774287484619332564597403632816768868845110259953541691709975889937073775752)
 
 @pytest.mark.fee_token
-@devnet_in_background()
 def test_fee_token_address():
     """Sends fee token request;"""
-    response = requests.get(f"{APP_URL}/fee_token")
+    response = app.test_client().get("/fee_token")
     assert response.status_code == 200
-    assert response.json().get("address") == "0x62230ea046a9a5fbc261ac77d03c8d41e5d442db2284587570ab46455fd2488"
-    assert response.json().get("symbol") == "ETH"
+    assert response.json.get("address") == "0x62230ea046a9a5fbc261ac77d03c8d41e5d442db2284587570ab46455fd2488"
+    assert response.json.get("symbol") == "ETH"
 
 
 def mint(address: str, amount: int, lite=False):

--- a/test/util.py
+++ b/test/util.py
@@ -24,9 +24,10 @@ def run_devnet_in_background(*args, stderr=None, stdout=None):
     Accepts extra args to pass to `starknet-devnet` command.
     Returns the process handle.
     """
-    # If accounts argument is not passed 0 is used as default
+    # If accounts argument is not passed, 1 is used as default
+    # used to be 0, but this was causing problems
     if "--accounts" not in args:
-        args = [*args, "--accounts", "0"]
+        args = [*args, "--accounts", "1"]
 
     command = ["poetry", "run", "starknet-devnet", "--host", HOST, "--port", PORT, *args]
     # pylint: disable=consider-using-with


### PR DESCRIPTION
## Usage related changes

- Fix dump/load and restart functionalities (fix #218)
- Wait for dump to finish (potentially a slowdown, but should eliminate race-related bugs)

## Development related changes

- Predeploy 1 account by default in tests (instead of 0 - this caused headache while trying to figure out why tests were passing but real-world was failing)
- Make rpc tests more independent of each other:
  - Set rpc fixtures module to function instead of scope
  - Restart state after each test
- Refactor code:
  - Expand functionality of `DevnetConfig` and move it from `starknet_wrapper.py` to `devnet_config.py`
  - Move `parse_args` from `util.py` to `devnet_config.py`
  - Moved account generation from `server.py` to `__init__` of `Accounts`.

## Checklist:

- [x] No linter errors
- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
