### PR TITLE
parametrization of test_deploy

### DIFF
--- a/test/test_general_workflow.py
+++ b/test/test_general_workflow.py
@@ -71,7 +71,7 @@ def test_general_workflow(expected_tx_hash, expected_block_hash):
     # check block and receipt after deployment
     assert_negative_block_input()
 
-    # check if in lite mode expected block hash is 0x1
+    # check if in lite mode block hash is 0x1
     if expected_block_hash == EXPECTED_SALTY_DEPLOY_BLOCK_HASH_LITE_MODE:
         assert_equal(expected_block_hash, get_block(parse=True)["block_hash"])
 


### PR DESCRIPTION
## Development related changes

- test_deploy.py now will use new syntax and will be parameterized

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
