### PR TITLE
Fix unappropriate rpc call return value

### DIFF
--- a/starknet_devnet/blueprints/rpc/call.py
+++ b/starknet_devnet/blueprints/rpc/call.py
@@ -31,7 +31,7 @@ async def call(request: FunctionCall, block_id: BlockId) -> List[Felt]:
         result = await state.starknet_wrapper.call(
             transaction=make_invoke_function(request)
         )
-        result["result"] = [rpc_felt(int(res, 16)) for res in result["result"]]
+        result = [rpc_felt(int(res, 16)) for res in result["result"]]
         return result
     except StarknetDevnetException as ex:
         raise RpcError(code=-1, message=ex.message) from ex

--- a/test/rpc/test_rpc_call.py
+++ b/test/rpc/test_rpc_call.py
@@ -28,7 +28,7 @@ def test_call(deploy_info):
     )
     result = resp["result"]
 
-    assert result["result"] == ["0x00"]
+    assert result == ["0x00"]
 
 
 @pytest.mark.usefixtures("run_devnet_in_background", "deploy_info")


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

- RPC call return value has format {..., result: [...]} instead of {..., result: {result: [...]}}

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->


## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [ ] All tests are passing

Closes: #251 