### PR TITLE
PYTHONUNBUFFERED=1 as default behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,6 @@ RUN pip3 install --no-cache /wheels/*
 
 RUN rm -rf /wheels
 
+ENV PYTHONUNBUFFERED=1
+
 ENTRYPOINT [ "starknet-devnet", "--host", "0.0.0.0", "--port", "5050" ]

--- a/README.md
+++ b/README.md
@@ -444,10 +444,10 @@ If your contract is using `print` in cairo hints (it was compiled with the `--di
 starknet-devnet 2> /dev/null
 ```
 
-To enable printing with a dockerized version of Devnet set `PYTHONUNBUFFERED=1`:
+To disable all the python logging you have to explicitly pass `PYTHONUNBUFFERED=0`:
 
-```
-docker run -p 127.0.0.1:5050:5050 -e PYTHONUNBUFFERED=1 shardlabs/starknet-devnet
+```sh
+docker run -p 127.0.0.1:5050:5050 -e PYTHONUNBUFFERED=0 shardlabs/starknet-devnet
 ```
 
 ## Predeployed accounts


### PR DESCRIPTION
## Usage related changes

- In order to hide all python logs user has now to explicitly pass `-e PYTHONUNBUFFERED=0`

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
