### PR TITLE
Hide predeployed accounts details

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ optional arguments:
                         predeployed; defaults to 1e+21 (wei)
   --seed SEED           Specify the seed for randomness of accounts to be
                         predeployed
+  --hide-predeployed-accounts
+                        Prevents from printing the predeployed accounts details
   --start-time START_TIME
                         Specify the start time of the genesis block in Unix
                         time seconds
@@ -452,7 +454,7 @@ docker run -p 127.0.0.1:5050:5050 -e PYTHONUNBUFFERED=0 shardlabs/starknet-devne
 
 ## Predeployed accounts
 
-Devnet predeploys `--accounts` with some `--initial-balance`. The accounts get charged for transactions according to the `--gas-price`. A `--seed` can be used to regenerate the same set of accounts. Read more about it in the [Run section](#run).
+Devnet predeploys `--accounts` with some `--initial-balance`. To hide the details of these accounts `--hide-predeployed-accounts`. The accounts get charged for transactions according to the `--gas-price`. A `--seed` can be used to regenerate the same set of accounts. Read more about it in the [Run section](#run).
 
 To get the code of the account (currently fork of OpenZeppelin's [v0.4.0b](https://github.com/OpenZeppelin/cairo-contracts/releases/tag/v0.4.0b)), use one of the following:
 

--- a/starknet_devnet/accounts.py
+++ b/starknet_devnet/accounts.py
@@ -23,7 +23,10 @@ class Accounts:
         self.list = []
 
         self.__generate()
-        if starknet_wrapper.config.accounts:
+        if (
+            starknet_wrapper.config.accounts
+            and not starknet_wrapper.hide_predeployed_accounts
+        ):
             self.__print()
 
     def __getitem__(self, index):

--- a/starknet_devnet/accounts.py
+++ b/starknet_devnet/accounts.py
@@ -25,7 +25,7 @@ class Accounts:
         self.__generate()
         if (
             starknet_wrapper.config.accounts
-            and not starknet_wrapper.hide_predeployed_accounts
+            and not starknet_wrapper.config.hide_predeployed_accounts
         ):
             self.__print()
 

--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -129,6 +129,11 @@ def parse_args(raw_args: List[str]):
         help="Specify the seed for randomness of accounts to be predeployed",
     )
     parser.add_argument(
+        "--hide-predeployed-accounts",
+        action="store_true",
+        help="Prevents from printing the predeployed accounts details",
+    )
+    parser.add_argument(
         "--start-time",
         action=NonNegativeAction,
         help="Specify the start time of the genesis block in Unix time seconds",
@@ -176,3 +181,4 @@ class DevnetConfig:
         self.start_time = self.args.start_time
         self.gas_price = self.args.gas_price
         self.lite_mode = self.args.lite_mode
+        self.hide_predeployed_accounts = self.args.hide_predeployed_accounts

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -83,6 +83,7 @@ class StarknetWrapper:
         self.starknet: Starknet = None
         self.__current_cached_state = None
         self.__initialized = False
+        self.hide_predeployed_accounts = config.hide_predeployed_accounts
         self.fee_token = FeeToken(self)
         self.accounts = Accounts(self)
 

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -83,7 +83,6 @@ class StarknetWrapper:
         self.starknet: Starknet = None
         self.__current_cached_state = None
         self.__initialized = False
-        self.hide_predeployed_accounts = config.hide_predeployed_accounts
         self.fee_token = FeeToken(self)
         self.accounts = Accounts(self)
 


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

- Users can now hide the details of the predeployed accounts. Default behavior is unchanged

## Development related changes

- Devnet output can be less verbose

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
