### PR TITLE
Update CI; fix seed logging

### DIFF
--- a/scripts/install_dev_tools.sh
+++ b/scripts/install_dev_tools.sh
@@ -13,4 +13,5 @@ echo "poetry: $(poetry --version)"
 
 # install dependencies
 poetry install
+poetry lock --check
 npm ci

--- a/starknet_devnet/accounts.py
+++ b/starknet_devnet/accounts.py
@@ -19,7 +19,11 @@ class Accounts:
         self.starknet_wrapper = starknet_wrapper
         self.__n_accounts = starknet_wrapper.config.accounts
         self.__initial_balance = starknet_wrapper.config.initial_balance
+
         self.__seed = starknet_wrapper.config.seed
+        if self.__seed is None:
+            self.__seed = random.getrandbits(32)
+
         self.list = []
 
         self.__generate()
@@ -42,11 +46,9 @@ class Accounts:
     def __generate(self):
         """Generates accounts without deploying them"""
         random_generator = random.Random()
-        self.__initial_balance = self.__initial_balance
+        random_generator.seed(self.__seed)
 
-        random_generator.seed(
-            self.__seed if self.__seed is not None else random_generator.getrandbits(32)
-        )
+        self.__initial_balance = self.__initial_balance
 
         for _ in range(self.__n_accounts):
             private_key = random_generator.getrandbits(128)

--- a/starknet_devnet/accounts.py
+++ b/starknet_devnet/accounts.py
@@ -48,8 +48,6 @@ class Accounts:
         random_generator = random.Random()
         random_generator.seed(self.__seed)
 
-        self.__initial_balance = self.__initial_balance
-
         for _ in range(self.__n_accounts):
             private_key = random_generator.getrandbits(128)
             public_key = private_to_stark_key(private_key)


### PR DESCRIPTION
## Usage related changes

- Looks like #264 was not done properly, now it should be fixed.

## Development related changes

- Since poetry 1.2 is being installed in CI/CD, we can now use the `poetry lock --check` functionality which it introduces.
  - Close #211 
- Improve image building
  - Remove `--rm` so that docker logs can be accessed in case of early exit  - close #280 
  - Refactor - better use of variables, not relying on hardcoded port

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] All tests are passing
