### PR TITLE
Fix positional args for addInvokeTransaction

### DIFF
--- a/starknet_devnet/blueprints/rpc/transactions.py
+++ b/starknet_devnet/blueprints/rpc/transactions.py
@@ -106,10 +106,10 @@ async def pending_transactions() -> List[RpcTransaction]:
 
 async def add_invoke_transaction(
     function_invocation: FunctionCall,
+    signature: List[Felt],
     max_fee: NumAsHex,
     version: NumAsHex,
     nonce: NumAsHex = None,
-    signature: Optional[List[Felt]] = None,
 ) -> dict:
     """
     Submit a new transaction to be added to the chain

--- a/starknet_devnet/blueprints/rpc/transactions.py
+++ b/starknet_devnet/blueprints/rpc/transactions.py
@@ -3,7 +3,7 @@ RPC transaction endpoints
 """
 
 import dataclasses
-from typing import List, Optional
+from typing import List
 
 from marshmallow.exceptions import MarshmallowError
 from starkware.starknet.services.api.contract_class import ContractClass

--- a/test/rpc/test_rpc_transactions.py
+++ b/test/rpc/test_rpc_transactions.py
@@ -313,6 +313,32 @@ def test_add_invoke_transaction(invoke_content):
     assert set(receipt.keys()) == {"transaction_hash"}
     assert receipt["transaction_hash"][:3] == "0x0"
 
+@pytest.mark.usefixtures("run_devnet_in_background")
+def test_add_invoke_transaction_positional_args(invoke_content):
+    """
+    Add invoke transaction
+    """
+    resp = rpc_call(
+        "starknet_addInvokeTransaction",
+        params=[
+            {
+                "contract_address": pad_zero(invoke_content["contract_address"]),
+                "entry_point_selector": pad_zero(
+                    invoke_content["entry_point_selector"]
+                ),
+                "calldata": [
+                    pad_zero(hex(int(data))) for data in invoke_content["calldata"]
+                ],
+            },
+            [pad_zero(sig) for sig in invoke_content["signature"]],
+            hex(0),
+            hex(SUPPORTED_RPC_TX_VERSION),
+        ],
+    )
+    receipt = resp["result"]
+
+    assert set(receipt.keys()) == {"transaction_hash"}
+    assert receipt["transaction_hash"][:3] == "0x0"
 
 @pytest.mark.usefixtures("run_devnet_in_background")
 def test_add_declare_transaction_on_incorrect_contract(declare_content):


### PR DESCRIPTION
## Usage related changes
This is definitely a bug in devnet that is not showing up in goerli (pathfinder). We should be able to call the RPC api with positional argument and those arguments should come in the right order, i.e. signature comes 2nd in the case of addInvokeTransaction. Check the v0.1.0 spec for details

I guess there is a good reason why you have set the signature back with None with both default and Optional. However, it prevents any positional arguments from working and you would want to comply to it. I assume Pathfinder requires you pass a an empty list if they do not want to provide a signature. The test cases are documented in #282

## Development related changes
N/A

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes <- What you expect I do?
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [ ] All tests are passing <- One test on L1/L2 is failing on my laptop. I assume it is unrelated and I am missing some setup/node version. 
