### PR TITLE
Feat/faster deploy

### DIFF
--- a/starknet_devnet/__init__.py
+++ b/starknet_devnet/__init__.py
@@ -3,13 +3,13 @@ Contains the server implementation and its utility classes and functions.
 """
 import sys
 from copy import copy
+import starkware.cairo.lang.vm.crypto
 from starkware.crypto.signature.fast_pedersen_hash import pedersen_hash
 from starkware.starknet.services.api.contract_class import ContractClass
 from crypto_cpp_py.cpp_bindings import cpp_hash
 
 
 __version__ = "0.3.2"
-
 
 
 def patched_pedersen_hash(left: int, right: int) -> int:
@@ -24,6 +24,11 @@ def patched_pedersen_hash(left: int, right: int) -> int:
 # instead of python implementation from cairo-lang package
 setattr(
     sys.modules["starkware.crypto.signature.fast_pedersen_hash"],
+    "pedersen_hash",
+    patched_pedersen_hash,
+)
+setattr(
+    sys.modules["starkware.cairo.lang.vm.crypto"],
     "pedersen_hash",
     patched_pedersen_hash,
 )


### PR DESCRIPTION
## Explanation
I found two issues when handling deploys:
- Cairo VM uses python-based pederesen hash and our patch of fast_pedersen_hash is not enough here. Monkeypatching it as saves around a second per contract hash calculation.
- `InternalDeploy` calculates a hash of contract provided every time it is created. `StarknetWrapper` does it once and then during deployment it is created again, so costly hash is calculated twice. Unfortunately `Starknet` doesn't expose the transaction used inside `deploy`, so the deployment logic had to be moved to `StarknetWrapper`, but it quite simple for devnet's requirements.

## Results
I prepared a script that deploys and declares a contract 10 times.

On master: 
```
DEVNET DEPLOY 68.47011825
DEVNET DECLARE 60.51540016700001
DEVNET TOTAL 128.985577375
```

On this branch:
```
DEVNET DEPLOY 25.193729042
DEVNET DECLARE 28.455156042
DEVNET TOTAL 53.648930041
```

It seems that performance now is on par with the testing framework.

<details>
<summary>Test code</summary>

```python
import asyncio
import os
from contextlib import contextmanager

from starknet_py.compile.compiler import Compiler
from starknet_py.contract import Contract
from starknet_py.net.client_models import Declare
from starknet_py.net.gateway_client import GatewayClient
from timeit import default_timer as timer

# Local network
from starknet_py.net.models import StarknetChainId
from starkware.starknet.services.api.contract_class import ContractClass

from starkware.starknet.testing.starknet import Starknet

# The path to the contract source code.
CAIRO_PATH = os.path.join(os.path.dirname(__file__), "cairo-contracts/src")
CONTRACT_FILE = os.path.join(
    CAIRO_PATH, "openzeppelin/token/erc20/presets/ERC20Mintable.cairo"
)
REPETITIONS = 10


@contextmanager
def measure(name):
    # Code to acquire resource, e.g.:
    start = timer()
    try:
        yield
    finally:
        end = timer()
        print(name, end - start)


compiled = Compiler(contract_source=[CONTRACT_FILE], cairo_path=[CAIRO_PATH]).compile_contract()


async def test_remote():
    client = GatewayClient("http://localhost:5050")
    declare = Declare(
        contract_class=ContractClass.loads(compiled),
        sender_address=1,
        nonce=0,
        max_fee=0,
        signature=[],
        version=0,
    )

    with measure("DEVNET TOTAL"):
        with measure("DEVNET DEPLOY"):
            for i in range(REPETITIONS):
                tx = await Contract.deploy(
                    client,
                    compiled_contract=compiled,
                    constructor_args=[1, 2, 3, 4, 5, 6],
                    salt=i,
                )

        with measure("DEVNET DECLARE"):
            for _ in range(REPETITIONS):
                tx = await client.declare(declare)

asyncio.run(test_remote())
```
</details>

## Related issues

Related to https://github.com/Shard-Labs/starknet-devnet/issues/52, it seems that user deploys a contract once per every test case. Probably we can ask user to check if performance after this is merged is acceptable.

## Usage related changes

This change shouldn't affect users. Apart from making deployments faster it can also increase speed of invocations and calls as the pedersen builtin in Cairo VM is faster now.

## Development related changes

No development related changes.

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [ ] Updated the tests **NA**
- [x] All tests are passing
