### PR TITLE
getNonce and addInvokeTransaction TxV1 on RPC v0.1

### DIFF
--- a/page/docs/guide/json-rpc-api.md
+++ b/page/docs/guide/json-rpc-api.md
@@ -31,4 +31,3 @@ Response:
 Methods currently not supported:
 
 - `starknet_protocolVersion` - will be removed in a future version of the specification
-- `starknet_getNonce`

--- a/starknet_devnet/blueprints/rpc/misc.py
+++ b/starknet_devnet/blueprints/rpc/misc.py
@@ -39,4 +39,7 @@ async def get_nonce(contract_address: Address) -> Felt:
     """
     Get the latest nonce associated with the given address
     """
-    raise NotImplementedError()
+    result = await state.starknet_wrapper.get_nonce(
+        contract_address=int(contract_address, 16)
+    )
+    return hex(result)

--- a/starknet_devnet/blueprints/rpc/structures/payloads.py
+++ b/starknet_devnet/blueprints/rpc/structures/payloads.py
@@ -250,9 +250,12 @@ def make_invoke_function(request_body: dict) -> InvokeFunction:
     """
 
     nonce = request_body.get("nonce")
+    entry_point_selector = request_body.get("entry_point_selector")
     return InvokeFunction(
         contract_address=int(request_body["contract_address"], 16),
-        entry_point_selector=int(request_body["entry_point_selector"], 16),
+        entry_point_selector=int(entry_point_selector, 16)
+        if entry_point_selector is not None
+        else None,
         calldata=[int(data, 16) for data in request_body["calldata"]],
         max_fee=int(request_body["max_fee"], 16) if "max_fee" in request_body else 0,
         version=int(request_body["version"], 16) if "version" in request_body else 0,

--- a/starknet_devnet/blueprints/rpc/transactions.py
+++ b/starknet_devnet/blueprints/rpc/transactions.py
@@ -114,16 +114,19 @@ async def add_invoke_transaction(
     """
     Submit a new transaction to be added to the chain
     """
+    entry_point_selector = function_invocation.get("entry_point_selector")
     invoke_function = InvokeFunction(
         contract_address=int(function_invocation["contract_address"], 16),
-        entry_point_selector=int(function_invocation["entry_point_selector"], 16),
+        entry_point_selector=int(entry_point_selector, 16)
+        if entry_point_selector is not None
+        else None,
         calldata=[int(data, 16) for data in function_invocation["calldata"]],
         max_fee=int(max_fee, 16),
         version=int(version, 16),
         signature=[int(data, 16) for data in signature]
         if signature is not None
         else [],
-        nonce=nonce,
+        nonce=int(nonce, 16) if nonce is not None else None,
     )
 
     _, transaction_hash = await state.starknet_wrapper.invoke(

--- a/test/invoke_rpc_v1.json
+++ b/test/invoke_rpc_v1.json
@@ -1,0 +1,12 @@
+{
+  "calldata": [
+    "10",
+    "11"
+  ],
+  "signature": [],
+  "contract_address": "0x0491c87978cb8d8a82c2a96dddd1888eb5ef8aa7209d5da86d2b703c3572032a",
+  "type": "INVOKE_FUNCTION",
+  "nonce": "0x1",
+  "version": "0x1",
+  "max_fee": "0x2"
+}

--- a/test/rpc/conftest.py
+++ b/test/rpc/conftest.py
@@ -27,6 +27,7 @@ from .rpc_utils import (
 
 DEPLOY_CONTENT = load_file_content("deploy_rpc.json")
 INVOKE_CONTENT = load_file_content("invoke_rpc.json")
+INVOKE_CONTENT_V1 = load_file_content("invoke_rpc_v1.json")
 DECLARE_CONTENT = load_file_content("declare.json")
 
 
@@ -84,6 +85,14 @@ def fixture_invoke_content() -> dict:
     Invoke content JSON object
     """
     return json.loads(INVOKE_CONTENT)
+
+
+@pytest.fixture(name="invoke_content_v1")
+def fixture_invoke_content_v1() -> dict:
+    """
+    Invoke content v1 JSON object
+    """
+    return json.loads(INVOKE_CONTENT_V1)
 
 
 @pytest.fixture(name="deploy_content")

--- a/test/rpc/test_rpc_misc.py
+++ b/test/rpc/test_rpc_misc.py
@@ -128,6 +128,5 @@ def test_call_get_nonce(deploy_info):
     """
     Test nonce
     """
-    # could be any legal method, just passing something to get params to fail
     ex = rpc_call(method="starknet_getNonce", params=[deploy_info["address"]])
     assert ex["result"] == "0x0"

--- a/test/rpc/test_rpc_misc.py
+++ b/test/rpc/test_rpc_misc.py
@@ -121,3 +121,13 @@ def test_call_with_invalid_params(params):
     # could be any legal method, just passing something to get params to fail
     ex = rpc_call(method="starknet_getClass", params=params)
     assert ex["error"] == {"code": -32602, "message": "Invalid params"}
+
+
+@pytest.mark.usefixtures("run_devnet_in_background")
+def test_call_get_nonce(deploy_info):
+    """
+    Test nonce
+    """
+    # could be any legal method, just passing something to get params to fail
+    ex = rpc_call(method="starknet_getNonce", params=[deploy_info["address"]])
+    assert ex["result"] == "0x0"

--- a/test/rpc/test_rpc_transactions.py
+++ b/test/rpc/test_rpc_transactions.py
@@ -315,6 +315,32 @@ def test_add_invoke_transaction(invoke_content):
 
 
 @pytest.mark.usefixtures("run_devnet_in_background")
+def test_add_invoke_transaction_v1(invoke_content_v1):
+    """
+    Add invoke transaction
+    """
+    resp = rpc_call(
+        "starknet_addInvokeTransaction",
+        params={
+            "function_invocation": {
+                "contract_address": pad_zero(invoke_content_v1["contract_address"]),
+                "calldata": [
+                    pad_zero(hex(int(data))) for data in invoke_content_v1["calldata"]
+                ],
+            },
+            "signature": [pad_zero(sig) for sig in invoke_content_v1["signature"]],
+            "max_fee": hex(1),
+            "version": hex(1),
+            "nonce": hex(1),
+        },
+    )
+    receipt = resp["result"]
+
+    assert set(receipt.keys()) == {"transaction_hash"}
+    assert receipt["transaction_hash"][:3] == "0x0"
+
+
+@pytest.mark.usefixtures("run_devnet_in_background")
 def test_add_invoke_transaction_positional_args(invoke_content):
     """
     Add invoke transaction

--- a/test/rpc/test_rpc_transactions.py
+++ b/test/rpc/test_rpc_transactions.py
@@ -329,7 +329,7 @@ def test_add_invoke_transaction_v1(invoke_content_v1):
                 ],
             },
             "signature": [pad_zero(sig) for sig in invoke_content_v1["signature"]],
-            "max_fee": hex(1),
+            "max_fee": hex(2),
             "version": hex(1),
             "nonce": hex(1),
         },


### PR DESCRIPTION
## Usage related changes
This PR enables `starknet_getNonce` and allow to collect and pass the `Nonce` from RPC v0.1 to the gateway. This also enables to execute an v1 transaction on RPC v0.1 by making `entry_point_selector` optional as expected by v1 from what I understand.

## Development related changes
There are 3 changes associated with this PR:
- implement `get_nonce` in RPC
- convert `nonce` with `hex` in `add_invoke_transaction` to make it consistent with `version` or `max_fee`
- make `entry_point_selector` optional on `make_invoke_function` in RPC and update `add_invoke_transaction` to also make it optional

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [x] Linked the issues which this PR resolves
- [ ] Updated the tests
- [x] All tests are passing

I am sorry for the tests but I do not know how to handle it properly