### PR TITLE
Allow RPC calls using block hash or number of latest block

### DIFF
--- a/page/docs/guide/json-rpc-api.md
+++ b/page/docs/guide/json-rpc-api.md
@@ -32,7 +32,8 @@ Methods currently not supported:
 
 - `starknet_protocolVersion` - will be removed in a future version of the specification
 
-Methods that require a `block_id` only support ids of the `latest` or `pending` block:
+Methods that require a `block_id` only support ids of the `latest` or `pending` block.
+Please note however, that the `pending` block will be the same block as the `latest`.
 
 ```js
 // Use latest

--- a/page/docs/guide/json-rpc-api.md
+++ b/page/docs/guide/json-rpc-api.md
@@ -31,3 +31,31 @@ Response:
 Methods currently not supported:
 
 - `starknet_protocolVersion` - will be removed in a future version of the specification
+
+Methods that require a `block_id` only support ids of the `latest` or `pending` block:
+
+```json
+// Use latest
+{
+  "block_id": "latest"
+}
+
+// or pending
+{
+  "block_id": "pending"
+}
+
+// or block number
+{
+  "block_id": {
+    "block_number": 1234  // Must be the number of the latest block
+  }
+}
+
+// or block hash
+{
+  "block_id": {
+    "block_hash": "0x1234" // Must be hash of the latest block
+  }
+}
+```

--- a/page/docs/guide/json-rpc-api.md
+++ b/page/docs/guide/json-rpc-api.md
@@ -34,7 +34,7 @@ Methods currently not supported:
 
 Methods that require a `block_id` only support ids of the `latest` or `pending` block:
 
-```json
+```js
 // Use latest
 {
   "block_id": "latest"

--- a/starknet_devnet/blocks.py
+++ b/starknet_devnet/blocks.py
@@ -31,7 +31,7 @@ class DevnetBlocks:
         self.__state_updates: Dict[int, BlockStateUpdate] = {}
         self.__hash2num: Dict[str, int] = {}
 
-    def __get_last_block(self):
+    def get_last_block(self) -> StarknetBlock:
         """Returns the last block stored so far."""
         number_of_blocks = self.get_number_of_blocks()
         return self.get_by_number(number_of_blocks - 1)
@@ -44,7 +44,7 @@ class DevnetBlocks:
         """Returns the block whose block_number is provided"""
         if block_number is None:
             if self.__num2block:
-                return self.__get_last_block()
+                return self.get_last_block()
             return self.origin.get_block_by_number(block_number)
 
         if block_number < 0:
@@ -116,7 +116,7 @@ class DevnetBlocks:
         if block_number == 0:
             parent_block_hash = 0
         else:
-            last_block = self.__get_last_block()
+            last_block = self.get_last_block()
             parent_block_hash = last_block.block_hash
 
         if is_empty_block:

--- a/starknet_devnet/blueprints/rpc/call.py
+++ b/starknet_devnet/blueprints/rpc/call.py
@@ -6,7 +6,10 @@ from typing import Any, List
 
 from starkware.starkware_utils.error_handling import StarkException
 
-from starknet_devnet.blueprints.rpc.utils import rpc_felt, assert_block_id_is_latest_or_pending
+from starknet_devnet.blueprints.rpc.utils import (
+    rpc_felt,
+    assert_block_id_is_latest_or_pending,
+)
 from starknet_devnet.blueprints.rpc.structures.payloads import (
     make_invoke_function,
     FunctionCall,

--- a/starknet_devnet/blueprints/rpc/call.py
+++ b/starknet_devnet/blueprints/rpc/call.py
@@ -6,7 +6,7 @@ from typing import Any, List
 
 from starkware.starkware_utils.error_handling import StarkException
 
-from starknet_devnet.blueprints.rpc.utils import rpc_felt, assert_block_id_is_latest
+from starknet_devnet.blueprints.rpc.utils import rpc_felt, assert_block_id_is_latest_or_pending
 from starknet_devnet.blueprints.rpc.structures.payloads import (
     make_invoke_function,
     FunctionCall,
@@ -33,7 +33,7 @@ async def call(request: FunctionCall, block_id: BlockId) -> List[Felt]:
     """
     Call a starknet function without creating a StarkNet transaction
     """
-    assert_block_id_is_latest(block_id)
+    assert_block_id_is_latest_or_pending(block_id)
 
     if not state.starknet_wrapper.contracts.is_deployed(
         int(request["contract_address"], 16)

--- a/starknet_devnet/blueprints/rpc/classes.py
+++ b/starknet_devnet/blueprints/rpc/classes.py
@@ -2,7 +2,7 @@
 RPC classes endpoints
 """
 
-from starknet_devnet.blueprints.rpc.utils import assert_block_id_is_latest, rpc_felt
+from starknet_devnet.blueprints.rpc.utils import assert_block_id_is_latest_or_pending, rpc_felt
 from starknet_devnet.blueprints.rpc.structures.payloads import rpc_contract_class
 from starknet_devnet.blueprints.rpc.structures.types import (
     BlockId,
@@ -34,7 +34,7 @@ async def get_class_hash_at(block_id: BlockId, contract_address: Address) -> Fel
     """
     Get the contract class hash in the given block for the contract deployed at the given address
     """
-    assert_block_id_is_latest(block_id)
+    assert_block_id_is_latest_or_pending(block_id)
 
     try:
         result = state.starknet_wrapper.contracts.get_class_hash_at(
@@ -52,7 +52,7 @@ async def get_class_at(block_id: BlockId, contract_address: Address) -> dict:
     """
     Get the contract class definition in the given block at the given address
     """
-    assert_block_id_is_latest(block_id)
+    assert_block_id_is_latest_or_pending(block_id)
 
     try:
         class_hash = state.starknet_wrapper.contracts.get_class_hash_at(

--- a/starknet_devnet/blueprints/rpc/classes.py
+++ b/starknet_devnet/blueprints/rpc/classes.py
@@ -2,7 +2,10 @@
 RPC classes endpoints
 """
 
-from starknet_devnet.blueprints.rpc.utils import assert_block_id_is_latest_or_pending, rpc_felt
+from starknet_devnet.blueprints.rpc.utils import (
+    assert_block_id_is_latest_or_pending,
+    rpc_felt,
+)
 from starknet_devnet.blueprints.rpc.structures.payloads import rpc_contract_class
 from starknet_devnet.blueprints.rpc.structures.types import (
     BlockId,

--- a/starknet_devnet/blueprints/rpc/storage.py
+++ b/starknet_devnet/blueprints/rpc/storage.py
@@ -2,7 +2,7 @@
 RPC storage endpoints
 """
 
-from starknet_devnet.blueprints.rpc.utils import assert_block_id_is_latest, rpc_felt
+from starknet_devnet.blueprints.rpc.utils import assert_block_id_is_latest_or_pending, rpc_felt
 from starknet_devnet.blueprints.rpc.structures.types import (
     Address,
     BlockId,
@@ -18,7 +18,7 @@ async def get_storage_at(
     """
     Get the value of the storage at the given address and key
     """
-    assert_block_id_is_latest(block_id)
+    assert_block_id_is_latest_or_pending(block_id)
 
     if not state.starknet_wrapper.contracts.is_deployed(int(contract_address, 16)):
         raise RpcError(code=20, message="Contract not found")

--- a/starknet_devnet/blueprints/rpc/storage.py
+++ b/starknet_devnet/blueprints/rpc/storage.py
@@ -2,7 +2,10 @@
 RPC storage endpoints
 """
 
-from starknet_devnet.blueprints.rpc.utils import assert_block_id_is_latest_or_pending, rpc_felt
+from starknet_devnet.blueprints.rpc.utils import (
+    assert_block_id_is_latest_or_pending,
+    rpc_felt,
+)
 from starknet_devnet.blueprints.rpc.structures.types import (
     Address,
     BlockId,

--- a/starknet_devnet/blueprints/rpc/transactions.py
+++ b/starknet_devnet/blueprints/rpc/transactions.py
@@ -22,7 +22,7 @@ from starkware.starkware_utils.error_handling import StarkException
 from starknet_devnet.blueprints.rpc.utils import (
     get_block_by_block_id,
     rpc_felt,
-    assert_block_id_is_latest,
+    assert_block_id_is_latest_or_pending,
 )
 from starknet_devnet.blueprints.rpc.structures.payloads import (
     rpc_transaction,
@@ -212,7 +212,7 @@ async def estimate_fee(request: RpcInvokeTransaction, block_id: BlockId) -> dict
     """
     Estimate the fee for a given StarkNet transaction
     """
-    assert_block_id_is_latest(block_id)
+    assert_block_id_is_latest_or_pending(block_id)
 
     if not state.starknet_wrapper.contracts.is_deployed(
         int(request["contract_address"], 16)

--- a/starknet_devnet/blueprints/rpc/utils.py
+++ b/starknet_devnet/blueprints/rpc/utils.py
@@ -53,16 +53,18 @@ def assert_block_id_is_latest_or_pending(block_id: BlockId) -> None:
     Assert block_id is "latest"/"pending" or a block hash or number of "latest"/"pending" block and throw RpcError otherwise
     """
     last_block = state.starknet_wrapper.blocks.get_last_block()
+    print(type(block_id), block_id)
 
-    if isinstance(block_id, BlockHashDict):
-        if block_id["block_hash"] == last_block.block_hash:
-            return
+    if isinstance(block_id, dict):
+        if "block_hash" in block_id:
+            if int(block_id["block_hash"], 16) == last_block.block_hash:
+                return
 
-    if isinstance(block_id, BlockNumberDict):
-        if block_id["block_number"] == last_block.block_number:
-            return
+        if "block_number" in block_id:
+            if int(block_id["block_number"]) == last_block.block_number:
+                return
 
-    if isinstance(block_id, BlockTag):
+    if isinstance(block_id, str):
         if block_id in ("latest", "pending"):
             return
 

--- a/starknet_devnet/blueprints/rpc/utils.py
+++ b/starknet_devnet/blueprints/rpc/utils.py
@@ -2,8 +2,11 @@
 RPC utilities
 """
 
-from starknet_devnet.blueprints.rpc.structures.types import BlockId, RpcError, Felt, BlockHashDict, BlockNumberDict, \
-    BlockTag
+from starknet_devnet.blueprints.rpc.structures.types import (
+    BlockId,
+    RpcError,
+    Felt,
+)
 from starknet_devnet.util import StarknetDevnetException
 from starknet_devnet.state import state
 

--- a/starknet_devnet/blueprints/rpc/utils.py
+++ b/starknet_devnet/blueprints/rpc/utils.py
@@ -73,7 +73,7 @@ def assert_block_id_is_latest_or_pending(block_id: BlockId) -> None:
 
     raise RpcError(
         code=-1,
-        message="Calls with block_id != 'latest' are not supported currently.",
+        message="Calls must be made with block_id of the latest or pending block. Other block_id are not supported."
     )
 
 

--- a/starknet_devnet/blueprints/rpc/utils.py
+++ b/starknet_devnet/blueprints/rpc/utils.py
@@ -55,10 +55,15 @@ def assert_block_id_is_latest_or_pending(block_id: BlockId) -> None:
     """
     Assert block_id is "latest"/"pending" or a block hash or number of "latest"/"pending" block and throw RpcError otherwise
     """
-    last_block = state.starknet_wrapper.blocks.get_last_block()
-    print(type(block_id), block_id)
-
     if isinstance(block_id, dict):
+        last_block = state.starknet_wrapper.blocks.get_last_block()
+
+        if "block_hash" in block_id and "block_number" in block_id:
+            raise RpcError(
+                code=-1,
+                message="Parameters block_hash and block_number are mutually exclusive.",
+            )
+
         if "block_hash" in block_id:
             if int(block_id["block_hash"], 16) == last_block.block_hash:
                 return

--- a/starknet_devnet/blueprints/rpc/utils.py
+++ b/starknet_devnet/blueprints/rpc/utils.py
@@ -78,7 +78,7 @@ def assert_block_id_is_latest_or_pending(block_id: BlockId) -> None:
 
     raise RpcError(
         code=-1,
-        message="Calls must be made with block_id of the latest or pending block. Other block_id are not supported."
+        message="Calls must be made with block_id of the latest or pending block. Other block_id are not supported.",
     )
 
 

--- a/test/rpc/conftest.py
+++ b/test/rpc/conftest.py
@@ -122,6 +122,9 @@ def fixture_gateway_block(deploy_info) -> dict:
 
 @pytest.fixture(name="latest_block")
 def fixture_latest_block() -> dict:
+    """
+    Latest block
+    """
     return get_latest_block()
 
 

--- a/test/rpc/conftest.py
+++ b/test/rpc/conftest.py
@@ -130,9 +130,10 @@ def fixture_latest_block() -> dict:
 
 def _block_to_block_id(block: dict, key: str) -> dict:
     block_id_map = {
-        "number": BlockNumberDict(block_number=block["block_number"]),
+        "number": BlockNumberDict(block_number=int(block["block_number"])),
         "hash": BlockHashDict(block_hash=pad_zero(block["block_hash"])),
         "tag": "latest",
+        "tag_pending": "pending",
     }
     return block_id_map[key]
 
@@ -145,7 +146,7 @@ def fixture_block_id(gateway_block, request) -> dict:
     return _block_to_block_id(gateway_block, request.param)
 
 
-@pytest.fixture(name="latest_block_id", params=["hash", "number", "tag"])
+@pytest.fixture(name="latest_block_id", params=["hash", "number", "tag", "tag_pending"])
 def fixture_latest_block_id(latest_block, request) -> dict:
     """
     Parametrized BlockId of latest gateway_block

--- a/test/rpc/conftest.py
+++ b/test/rpc/conftest.py
@@ -23,6 +23,7 @@ from .rpc_utils import (
     get_block_with_transaction,
     pad_zero,
     add_transaction,
+    get_latest_block,
 )
 
 DEPLOY_CONTENT = load_file_content("deploy_rpc.json")
@@ -119,17 +120,34 @@ def fixture_gateway_block(deploy_info) -> dict:
     return get_block_with_transaction(deploy_info["transaction_hash"])
 
 
-@pytest.fixture(name="block_id")
+@pytest.fixture(name="latest_block")
+def fixture_latest_block() -> dict:
+    return get_latest_block()
+
+
+def _block_to_block_id(block: dict, key: str) -> dict:
+    block_id_map = {
+        "number": BlockNumberDict(block_number=block["block_number"]),
+        "hash": BlockHashDict(block_hash=pad_zero(block["block_hash"])),
+        "tag": "latest",
+    }
+    return block_id_map[key]
+
+
+@pytest.fixture(name="block_id", params=["hash", "number", "tag"])
 def fixture_block_id(gateway_block, request) -> dict:
     """
     BlockId of gateway_block depending on type in request
     """
-    block_id_map = {
-        "hash": BlockNumberDict(block_number=gateway_block["block_number"]),
-        "number": BlockHashDict(block_hash=pad_zero(gateway_block["block_hash"])),
-        "tag": "latest",
-    }
-    return block_id_map[request.param]
+    return _block_to_block_id(gateway_block, request.param)
+
+
+@pytest.fixture(name="latest_block_id")
+def fixture_latest_block_id(latest_block, request) -> dict:
+    """
+    Parametrized BlockId of latest gateway_block
+    """
+    return _block_to_block_id(latest_block, request.param)
 
 
 @pytest.fixture(name="rpc_invoke_tx_common")

--- a/test/rpc/conftest.py
+++ b/test/rpc/conftest.py
@@ -145,7 +145,7 @@ def fixture_block_id(gateway_block, request) -> dict:
     return _block_to_block_id(gateway_block, request.param)
 
 
-@pytest.fixture(name="latest_block_id")
+@pytest.fixture(name="latest_block_id", params=["hash", "number", "tag"])
 def fixture_latest_block_id(latest_block, request) -> dict:
     """
     Parametrized BlockId of latest gateway_block

--- a/test/rpc/rpc_utils.py
+++ b/test/rpc/rpc_utils.py
@@ -81,6 +81,12 @@ def get_block_with_transaction(transaction_hash: str) -> dict:
     return block
 
 
+def get_latest_block() -> dict:
+    """
+    Retrive the latest block
+    """
+    return gateway_call("get_block", blockNumber="latest")
+
 def pad_zero(felt: str) -> Felt:
     """
     Convert felt with format `0xValue` to format `0x0Value`

--- a/test/rpc/rpc_utils.py
+++ b/test/rpc/rpc_utils.py
@@ -87,6 +87,7 @@ def get_latest_block() -> dict:
     """
     return gateway_call("get_block", blockNumber="latest")
 
+
 def pad_zero(felt: str) -> Felt:
     """
     Convert felt with format `0xValue` to format `0x0Value`

--- a/test/rpc/test_rpc_blocks.py
+++ b/test/rpc/test_rpc_blocks.py
@@ -20,7 +20,6 @@ from ..shared import (
 
 
 @pytest.mark.usefixtures("run_devnet_in_background")
-@pytest.mark.parametrize("block_id", ["hash", "number", "tag"], indirect=True)
 def test_get_block_with_tx_hashes(deploy_info, gateway_block, block_id):
     """
     Get block with tx hashes
@@ -63,7 +62,6 @@ def test_get_block_with_tx_hashes_raises_on_incorrect_block_id(block_id):
 
 
 @pytest.mark.usefixtures("run_devnet_in_background", "deploy_info")
-@pytest.mark.parametrize("block_id", ["hash", "number", "tag"], indirect=True)
 def test_get_block_with_txs(gateway_block, block_id):
     """
     Get block with txs by block id
@@ -118,7 +116,6 @@ def test_get_block_with_txs_raises_on_incorrect_block_id(block_id):
 
 
 @pytest.mark.usefixtures("run_devnet_in_background", "deploy_info", "gateway_block")
-@pytest.mark.parametrize("block_id", ["hash", "number", "tag"], indirect=True)
 def test_get_block_transaction_count(block_id):
     """
     Get count of transactions in block by block id

--- a/test/rpc/test_rpc_call.py
+++ b/test/rpc/test_rpc_call.py
@@ -69,7 +69,10 @@ def test_call_raises_on_both_hash_and_number():
         },
     )
 
-    assert ex["error"] == {"code": -1, "message": "Parameters block_hash and block_number are mutually exclusive."}
+    assert ex["error"] == {
+        "code": -1,
+        "message": "Parameters block_hash and block_number are mutually exclusive.",
+    }
 
 
 @pytest.mark.usefixtures("run_devnet_in_background")

--- a/test/rpc/test_rpc_call.py
+++ b/test/rpc/test_rpc_call.py
@@ -141,7 +141,7 @@ def test_call_raises_on_incorrect_block_hash(deploy_info):
 
     assert ex["error"] == {
         "code": -1,
-        "message": "Calls with block_id != 'latest' are not supported currently.",
+        "message": "Calls must be made with block_id of the latest or pending block. Other block_id are not supported.",
     }
 
 

--- a/test/rpc/test_rpc_call.py
+++ b/test/rpc/test_rpc_call.py
@@ -52,6 +52,26 @@ def test_call_raises_on_incorrect_contract_address():
     assert ex["error"] == {"code": 20, "message": "Contract not found"}
 
 
+@pytest.mark.usefixtures("run_devnet_in_background", "deploy_info")
+def test_call_raises_on_both_hash_and_number():
+    """
+    Call contract with incorrect address
+    """
+    ex = rpc_call(
+        "starknet_call",
+        params={
+            "request": {
+                "contract_address": "0x07b529269b82f3f3ebbb2c463a9e1edaa2c6eea8fa308ff70b30398766a2e20c",
+                "entry_point_selector": hex(get_selector_from_name("get_balance")),
+                "calldata": [],
+            },
+            "block_id": {"block_hash": "0x1234", "block_number": 1234},
+        },
+    )
+
+    assert ex["error"] == {"code": -1, "message": "Parameters block_hash and block_number are mutually exclusive."}
+
+
 @pytest.mark.usefixtures("run_devnet_in_background")
 def test_call_raises_on_incorrect_selector(deploy_info):
     """

--- a/test/rpc/test_rpc_call.py
+++ b/test/rpc/test_rpc_call.py
@@ -55,7 +55,7 @@ def test_call_raises_on_incorrect_contract_address():
 @pytest.mark.usefixtures("run_devnet_in_background", "deploy_info")
 def test_call_raises_on_both_hash_and_number():
     """
-    Call contract with incorrect address
+    Call contract with both block hash and block number provided at the same time
     """
     ex = rpc_call(
         "starknet_call",

--- a/test/rpc/test_rpc_call.py
+++ b/test/rpc/test_rpc_call.py
@@ -9,7 +9,7 @@ from .rpc_utils import rpc_call, pad_zero
 
 
 @pytest.mark.usefixtures("run_devnet_in_background")
-def test_call(deploy_info):
+def test_call(deploy_info, latest_block_id):
     """
     Call contract
     """
@@ -23,9 +23,10 @@ def test_call(deploy_info):
                 "entry_point_selector": hex(get_selector_from_name("get_balance")),
                 "calldata": [],
             },
-            "block_id": "latest",
+            "block_id": latest_block_id,
         },
     )
+    assert "error" not in resp
     result = resp["result"]
 
     assert result == ["0x045"]

--- a/test/rpc/test_rpc_storage.py
+++ b/test/rpc/test_rpc_storage.py
@@ -92,5 +92,5 @@ def test_get_storage_at_raises_on_incorrect_block_id(deploy_info):
 
     assert ex["error"] == {
         "code": -1,
-        "message": "Calls with block_id != 'latest' are not supported currently.",
+        "message": "Calls must be made with block_id of the latest or pending block. Other block_id are not supported.",
     }


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

- Currently, in many places in the RPC, it is required that the users uses `"latest"` as block hash/number. With this PR it is also possible to use a `block_hash` or `block_number` if they belong to the latest block.
- This PR allows making calls  with block tag `"pending"` block, though it is still treated as a `"latest"` block (up to discussion if this should be included).
- Changed fixtures using  pytest.mark.parametrize usages with `indirect=True`, to parametrized fixtures.

## Development related changes

None

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [ ] Linked the issues which this PR resolves
- [x] Updated the tests
- [ ] All tests are passing
