### PR TITLE
Store contract on deploy_account tx

### DIFF
--- a/test/shared.py
+++ b/test/shared.py
@@ -1,5 +1,11 @@
 """Shared values between tests"""
 
+import json
+
+from starkware.starknet.third_party.open_zeppelin.starknet_contracts import (
+    account_contract as oz_account_class,
+)
+
 ARTIFACTS_PATH = "test/artifacts/contracts/cairo"
 CONTRACT_PATH = f"{ARTIFACTS_PATH}/contract.cairo/contract.json"
 ABI_PATH = f"{ARTIFACTS_PATH}/contract.cairo/contract_abi.json"
@@ -10,6 +16,10 @@ EVENTS_ABI_PATH = f"{ARTIFACTS_PATH}/events.cairo/events_abi.json"
 FAILING_CONTRACT_PATH = f"{ARTIFACTS_PATH}/always_fail.cairo/always_fail.json"
 DEPLOYER_CONTRACT_PATH = f"{ARTIFACTS_PATH}/deployer.cairo/deployer.json"
 DEPLOYER_ABI_PATH = f"{ARTIFACTS_PATH}/deployer.cairo/deployer_abi.json"
+
+STARKNET_CLI_ACCOUNT_ABI_PATH = f"{ARTIFACTS_PATH}/starknet_cli_oz_account_abi.json"
+with open(STARKNET_CLI_ACCOUNT_ABI_PATH, "w", encoding="utf-8") as oz_account_abi_file:
+    json.dump(oz_account_class.abi, oz_account_abi_file)
 
 L1L2_CONTRACT_PATH = f"{ARTIFACTS_PATH}/l1l2.cairo/l1l2.json"
 L1L2_ABI_PATH = f"{ARTIFACTS_PATH}/l1l2.cairo/l1l2_abi.json"

--- a/test/test_deploy.py
+++ b/test/test_deploy.py
@@ -38,8 +38,9 @@ from .util import (
 from .shared import (
     ABI_PATH,
     CONTRACT_PATH,
-    SUPPORTED_TX_VERSION,
     PREDEPLOY_ACCOUNT_CLI_ARGS,
+    STARKNET_CLI_ACCOUNT_ABI_PATH,
+    SUPPORTED_TX_VERSION,
 )
 
 
@@ -161,6 +162,14 @@ def test_deploy_account():
     # deploy the account
     tx_after = send_tx(deploy_account_tx, TransactionType.DEPLOY_ACCOUNT)
     assert_tx_status(tx_after["transaction_hash"], "ACCEPTED_ON_L2")
+
+    # assert that contract can be interacted with
+    retrieved_public_key = call(
+        function="get_public_key",
+        address=hex(account_address),
+        abi_path=STARKNET_CLI_ACCOUNT_ABI_PATH,
+    )
+    assert int(retrieved_public_key, 16) == public_key
 
     # deploy a contract for testing
     init_balance = 10

--- a/test/util.py
+++ b/test/util.py
@@ -316,7 +316,7 @@ def estimate_fee(function, inputs, address, abi_path, signature=None, nonce=None
     return extract_fee(output.stdout)
 
 
-def call(function, address, abi_path, inputs=None):
+def call(function: str, address: str, abi_path: str, inputs=None):
     """Wrapper around starknet call"""
     args = [
         "call",


### PR DESCRIPTION
## Usage related changes

- Close #311 

## Development related changes

- Expand `test/shared.py` with code that adds the ABI of the account used by Starknet CLI (and also currently used in our tests to test the deploy account tx type)
- Expand existing deploy_account test with a few code lines that assert that the account contract can be interacted with

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
