### PR TITLE
RPC `estimate_fee` for Declare transactions

### DIFF
--- a/starknet_devnet/blueprints/rpc/call.py
+++ b/starknet_devnet/blueprints/rpc/call.py
@@ -11,8 +11,8 @@ from starknet_devnet.blueprints.rpc.utils import (
     assert_block_id_is_latest_or_pending,
 )
 from starknet_devnet.blueprints.rpc.structures.payloads import (
-    make_invoke_function,
     FunctionCall,
+    make_call_function,
 )
 from starknet_devnet.blueprints.rpc.structures.types import (
     Felt,
@@ -46,7 +46,7 @@ async def call(request: FunctionCall, block_id: BlockId) -> List[Felt]:
     _validate_calldata(request["calldata"])
     try:
         result = await state.starknet_wrapper.call(
-            transaction=make_invoke_function(request)
+            transaction=make_call_function(request)
         )
         return [rpc_felt(res) for res in result["result"]]
     except StarknetDevnetException as ex:

--- a/starknet_devnet/blueprints/rpc/structures/payloads.py
+++ b/starknet_devnet/blueprints/rpc/structures/payloads.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 
 from typing import Callable, Union, List, Optional
 
+from marshmallow.exceptions import MarshmallowError
 from starkware.starknet.definitions.general_config import StarknetGeneralConfig
 from starkware.starknet.public.abi import AbiEntryType
 from starkware.starknet.services.api.contract_class import ContractClass
+from starkware.starknet.services.api.feeder_gateway.request_objects import CallFunction
 from starkware.starknet.services.api.feeder_gateway.response_objects import (
     StarknetBlock,
     InvokeSpecificInfo,
@@ -20,8 +22,17 @@ from starkware.starknet.services.api.feeder_gateway.response_objects import (
     L1HandlerSpecificInfo,
     FeeEstimationInfo,
 )
-from starkware.starknet.services.api.gateway.transaction import InvokeFunction
-from starkware.starknet.services.api.gateway.transaction_utils import compress_program
+from starkware.starknet.services.api.gateway.transaction import (
+    InvokeFunction,
+    Declare,
+    Deploy,
+    DeployAccount,
+)
+from starkware.starknet.services.api.gateway.transaction_utils import (
+    compress_program,
+    decompress_program,
+)
+from starkware.starkware_utils.error_handling import StarkException
 from typing_extensions import TypedDict, Literal
 
 from starknet_devnet.blueprints.rpc.structures.types import (
@@ -33,9 +44,10 @@ from starknet_devnet.blueprints.rpc.structures.types import (
     TxnHash,
     Address,
     NumAsHex,
-    TxnType,
+    RpcTxnType,
     rpc_txn_type,
     Signature,
+    RpcError,
 )
 from starknet_devnet.blueprints.rpc.utils import rpc_root, rpc_felt
 from starknet_devnet.constants import LEGACY_RPC_TX_VERSION
@@ -100,7 +112,7 @@ async def rpc_block(
 class RpcBroadcastedTxnCommon(TypedDict):
     """TypedDict for RpcBroadcastedTxnCommon"""
 
-    type: TxnType
+    type: RpcTxnType
     max_fee: Felt
     version: NumAsHex
     signature: Signature
@@ -137,7 +149,7 @@ class RpcBroadcastedDeployTxn(TypedDict):
 
     contract_class: RpcContractClass
     version: NumAsHex
-    type: TxnType
+    type: RpcTxnType
     contract_address_salt: Felt
     constructor_calldata: List[Felt]
 
@@ -177,7 +189,7 @@ class RpcL1HandlerTransaction(TypedDict):
     calldata: List[Felt]
     transaction_hash: TxnHash
     version: NumAsHex
-    type: TxnType
+    type: RpcTxnType
     nonce: Felt
 
 
@@ -194,7 +206,7 @@ class RpcDeployTransaction(TypedDict):
     transaction_hash: TxnHash
     class_hash: Felt
     version: NumAsHex
-    type: TxnType
+    type: RpcTxnType
     contract_address_salt: Felt
     constructor_calldata: List[Felt]
 
@@ -225,6 +237,17 @@ class FunctionCall(TypedDict):
     contract_address: Address
     entry_point_selector: Felt
     calldata: List[Felt]
+
+
+def make_call_function(function_call: FunctionCall) -> CallFunction:
+    """
+    Convert RPC FunctionCall to CallFunction
+    """
+    return CallFunction(
+        contract_address=int(function_call["contract_address"], 16),
+        entry_point_selector=int(function_call["entry_point_selector"], 16),
+        calldata=[int(data, 16) for data in function_call["calldata"]],
+    )
 
 
 def rpc_invoke_transaction(
@@ -330,35 +353,97 @@ def rpc_fee_estimate(fee_estimate: FeeEstimationInfo) -> dict:
     return result
 
 
-def make_invoke_function(request_body: dict) -> InvokeFunction:
+def make_invoke_function(invoke_transaction: RpcBroadcastedInvokeTxn) -> InvokeFunction:
     """
-    Convert RPC request to internal InvokeFunction
+    Convert RpcBroadcastedInvokeTxn to InvokeFunction
     """
-    version = int(request_body.get("version", str(LEGACY_RPC_TX_VERSION)), 16)
-    nonce = request_body.get("nonce")
+    version = int(invoke_transaction["version"], 16)
+    nonce = invoke_transaction.get("nonce")
 
     common_data = {
-        "max_fee": int(request_body.get("max_fee", "0"), 16),
+        "max_fee": int(invoke_transaction.get("max_fee", "0"), 16),
         "version": version,
-        "signature": [int(data, 16) for data in request_body.get("signature", [])],
+        "signature": [
+            int(data, 16) for data in invoke_transaction.get("signature", [])
+        ],
         "nonce": int(nonce, 16) if nonce is not None else None,
     }
 
     if version == LEGACY_RPC_TX_VERSION:
         invoke_function = InvokeFunction(
-            contract_address=int(request_body["contract_address"], 16),
-            entry_point_selector=int(request_body["entry_point_selector"], 16),
-            calldata=[int(data, 16) for data in request_body.get("calldata", [])],
+            contract_address=int(invoke_transaction["contract_address"], 16),
+            entry_point_selector=int(invoke_transaction["entry_point_selector"], 16),
+            calldata=[int(data, 16) for data in invoke_transaction.get("calldata", [])],
             **common_data,
         )
     else:
         invoke_function = InvokeFunction(
-            contract_address=int(request_body["sender_address"], 16),
-            calldata=[int(data, 16) for data in request_body.get("calldata", [])],
+            contract_address=int(invoke_transaction["sender_address"], 16),
+            calldata=[int(data, 16) for data in invoke_transaction.get("calldata", [])],
             **common_data,
         )
 
     return invoke_function
+
+
+def make_declare(declare_transaction: RpcBroadcastedDeclareTxn) -> Declare:
+    """
+    Convert RpcDeclareTransaction to Declare
+    """
+    contract_class = declare_transaction["contract_class"]
+    if "abi" not in contract_class:
+        contract_class["abi"] = []
+
+    try:
+        contract_class = decompress_program(declare_transaction, False)[
+            "contract_class"
+        ]
+        contract_class = ContractClass.load(contract_class)
+    except (StarkException, TypeError, MarshmallowError) as ex:
+        raise RpcError(code=50, message="Invalid contract class") from ex
+
+    nonce = declare_transaction.get("nonce")
+    declare_transaction = Declare(
+        contract_class=contract_class,
+        sender_address=int(declare_transaction["sender_address"], 16),
+        nonce=int(nonce, 16) if nonce is not None else 0,
+        version=int(declare_transaction["version"], 16),
+        max_fee=int(declare_transaction["max_fee"], 16),
+        signature=[int(sig, 16) for sig in declare_transaction["signature"]],
+    )
+    return declare_transaction
+
+
+def make_deploy(deploy_transaction: RpcDeployTransaction) -> Deploy:
+    """
+    Convert RpcDeployTransaction to Deploy
+    """
+    contract_class = deploy_transaction["contract_class"]
+    if "abi" not in contract_class:
+        contract_class["abi"] = []
+
+    try:
+        contract_class = decompress_program(deploy_transaction, False)["contract_class"]
+        contract_class = ContractClass.load(contract_class)
+    except (StarkException, TypeError, MarshmallowError) as ex:
+        raise RpcError(code=50, message="Invalid contract class") from ex
+
+    deploy_transaction = Deploy(
+        contract_address_salt=int(deploy_transaction["contract_address_salt"], 16),
+        constructor_calldata=[
+            int(data, 16) for data in deploy_transaction["constructor_calldata"]
+        ],
+        contract_definition=contract_class,
+        version=int(deploy_transaction["version"], 16),
+    )
+    return deploy_transaction
+
+
+def make_deploy_account(txn) -> DeployAccount:
+    """
+    Convert RpcDeployTransaction to DeployAccount
+    """
+    raise NotImplementedError
 
 
 class EntryPoint(TypedDict):

--- a/starknet_devnet/blueprints/rpc/structures/payloads.py
+++ b/starknet_devnet/blueprints/rpc/structures/payloads.py
@@ -26,7 +26,6 @@ from starkware.starknet.services.api.gateway.transaction import (
     InvokeFunction,
     Declare,
     Deploy,
-    DeployAccount,
 )
 from starkware.starknet.services.api.gateway.transaction_utils import (
     compress_program,
@@ -437,13 +436,6 @@ def make_deploy(deploy_transaction: RpcDeployTransaction) -> Deploy:
         version=int(deploy_transaction["version"], 16),
     )
     return deploy_transaction
-
-
-def make_deploy_account(txn) -> DeployAccount:
-    """
-    Convert RpcDeployTransaction to DeployAccount
-    """
-    raise NotImplementedError
 
 
 class EntryPoint(TypedDict):

--- a/starknet_devnet/blueprints/rpc/structures/responses.py
+++ b/starknet_devnet/blueprints/rpc/structures/responses.py
@@ -17,7 +17,7 @@ from starknet_devnet.blueprints.rpc.structures.types import (
     BlockNumber,
     BlockHash,
     TxnStatus,
-    TxnType,
+    RpcTxnType,
     rpc_txn_type,
 )
 from starknet_devnet.blueprints.rpc.utils import rpc_felt
@@ -76,7 +76,7 @@ class RpcBaseTransactionReceipt(TypedDict):
     status: TxnStatus
     block_hash: BlockHash
     block_number: BlockNumber
-    type: TxnType
+    type: RpcTxnType
     messages_sent: List[MessageToL1]
     events: List[Event]
 
@@ -168,7 +168,7 @@ def rpc_base_transaction_receipt(txr: TransactionReceipt) -> dict:
         }
         return mapping[txr.status]
 
-    def txn_type() -> TxnType:
+    def txn_type() -> RpcTxnType:
         transaction = state.starknet_wrapper.transactions.get_transaction(
             hex(txr.transaction_hash)
         ).transaction

--- a/starknet_devnet/blueprints/rpc/structures/types.py
+++ b/starknet_devnet/blueprints/rpc/structures/types.py
@@ -4,10 +4,10 @@ RPC types
 
 from enum import Enum
 from typing import Union, List
-from typing_extensions import Literal, TypedDict
 
+from starkware.starknet.definitions.transaction_type import TransactionType
 from starkware.starknet.services.api.feeder_gateway.response_objects import BlockStatus
-
+from typing_extensions import Literal, TypedDict
 
 Felt = str
 
@@ -37,16 +37,16 @@ TxnStatus = Literal["PENDING", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1", "REJECTED"]
 RpcBlockStatus = Literal["PENDING", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1", "REJECTED"]
 
 
-def rpc_block_status(block_status: BlockStatus) -> RpcBlockStatus:
+def rpc_block_status(block_status: str) -> RpcBlockStatus:
     """
     Convert gateway BlockStatus to RpcBlockStatus
     """
     block_status_map = {
-        "PENDING": "PENDING",
-        "ABORTED": "REJECTED",
-        "REVERTED": "REJECTED",
-        "ACCEPTED_ON_L2": "ACCEPTED_ON_L2",
-        "ACCEPTED_ON_L1": "ACCEPTED_ON_L1",
+        BlockStatus.PENDING.name: "PENDING",
+        BlockStatus.ABORTED.name: "REJECTED",
+        BlockStatus.REVERTED.name: "REJECTED",
+        BlockStatus.ACCEPTED_ON_L2.name: "ACCEPTED_ON_L2",
+        BlockStatus.ACCEPTED_ON_L1.name: "ACCEPTED_ON_L1",
     }
     return block_status_map[block_status]
 
@@ -57,18 +57,19 @@ NumAsHex = str
 
 # Pending transactions will not be supported since it
 # doesn't make much sense with the current implementation of devnet
-TxnType = Literal["DECLARE", "DEPLOY", "INVOKE", "L1_HANDLER"]
+RpcTxnType = Literal["DECLARE", "DEPLOY", "INVOKE", "L1_HANDLER"]
 
 
-def rpc_txn_type(transaction_type: str) -> TxnType:
+def rpc_txn_type(transaction_type: str) -> RpcTxnType:
     """
-    Convert gateway transaction type to RPC TxnType
+    Convert gateway TransactionType name to RPCTxnType
     """
     txn_type_map = {
-        "DEPLOY": "DEPLOY",
-        "DECLARE": "DECLARE",
-        "INVOKE_FUNCTION": "INVOKE",
-        "L1_HANDLER": "L1_HANDLER",
+        TransactionType.DEPLOY.name: "DEPLOY",
+        TransactionType.DECLARE.name: "DECLARE",
+        TransactionType.INVOKE_FUNCTION.name: "INVOKE",
+        TransactionType.L1_HANDLER.name: "L1_HANDLER",
+        TransactionType.DEPLOY_ACCOUNT.name: "DEPLOY_ACCOUNT",
     }
     if transaction_type not in txn_type_map:
         raise RpcError(

--- a/starknet_devnet/blueprints/rpc/structures/types.py
+++ b/starknet_devnet/blueprints/rpc/structures/types.py
@@ -69,7 +69,6 @@ def rpc_txn_type(transaction_type: str) -> RpcTxnType:
         TransactionType.DECLARE.name: "DECLARE",
         TransactionType.INVOKE_FUNCTION.name: "INVOKE",
         TransactionType.L1_HANDLER.name: "L1_HANDLER",
-        TransactionType.DEPLOY_ACCOUNT.name: "DEPLOY_ACCOUNT",
     }
     if transaction_type not in txn_type_map:
         raise RpcError(

--- a/starknet_devnet/blueprints/rpc/transactions.py
+++ b/starknet_devnet/blueprints/rpc/transactions.py
@@ -23,7 +23,6 @@ from starknet_devnet.blueprints.rpc.structures.payloads import (
     RpcBroadcastedTxn,
     make_declare,
     make_deploy,
-    make_deploy_account,
 )
 from starknet_devnet.blueprints.rpc.structures.responses import (
     rpc_transaction_receipt,
@@ -155,8 +154,6 @@ def make_transaction(txn: RpcBroadcastedTxn) -> AccountTransaction:
         return make_declare(txn)
     if txn_type == "DEPLOY":
         return make_deploy(txn)
-    if txn_type == "DEPLOY_ACCOUNT":
-        return make_deploy_account(txn)
     raise NotImplementedError(f"Unexpected type {txn['type']}.")
 
 

--- a/starknet_devnet/blueprints/rpc/transactions.py
+++ b/starknet_devnet/blueprints/rpc/transactions.py
@@ -4,17 +4,12 @@ RPC transaction endpoints
 
 from typing import List
 
-from marshmallow.exceptions import MarshmallowError
-from starkware.starknet.services.api.contract_class import ContractClass
 from starkware.starknet.services.api.feeder_gateway.response_objects import (
     TransactionStatus,
 )
 from starkware.starknet.services.api.gateway.transaction import (
-    InvokeFunction,
-    Declare,
-    Deploy,
+    AccountTransaction,
 )
-from starkware.starknet.services.api.gateway.transaction_utils import decompress_program
 from starkware.starkware_utils.error_handling import StarkException
 
 from starknet_devnet.blueprints.rpc.structures.payloads import (
@@ -26,6 +21,9 @@ from starknet_devnet.blueprints.rpc.structures.payloads import (
     RpcBroadcastedDeclareTxn,
     RpcBroadcastedDeployTxn,
     RpcBroadcastedTxn,
+    make_declare,
+    make_deploy,
+    make_deploy_account,
 )
 from starknet_devnet.blueprints.rpc.structures.responses import (
     rpc_transaction_receipt,
@@ -43,7 +41,6 @@ from starknet_devnet.blueprints.rpc.utils import (
     rpc_felt,
     assert_block_id_is_latest_or_pending,
 )
-from starknet_devnet.constants import LEGACY_RPC_TX_VERSION
 from starknet_devnet.state import state
 from starknet_devnet.util import StarknetDevnetException
 
@@ -105,28 +102,7 @@ async def add_invoke_transaction(invoke_transaction: RpcBroadcastedInvokeTxn) ->
     """
     Submit a new transaction to be added to the chain
     """
-    version = int(invoke_transaction["version"], 16)
-
-    common_data = {
-        "calldata": [int(data, 16) for data in invoke_transaction["calldata"]],
-        "max_fee": int(invoke_transaction["max_fee"], 16),
-        "version": int(invoke_transaction["version"], 16),
-        "signature": [int(data, 16) for data in invoke_transaction["signature"]],
-    }
-
-    if version == LEGACY_RPC_TX_VERSION:
-        invoke_function = InvokeFunction(
-            contract_address=int(invoke_transaction["contract_address"], 16),
-            entry_point_selector=int(invoke_transaction["entry_point_selector"], 16),
-            nonce=None,
-            **common_data,
-        )
-    else:
-        invoke_function = InvokeFunction(
-            contract_address=int(invoke_transaction["sender_address"], 16),
-            nonce=int(invoke_transaction["nonce"], 16),
-            **common_data,
-        )
+    invoke_function = make_invoke_function(invoke_transaction)
 
     _, transaction_hash = await state.starknet_wrapper.invoke(
         external_tx=invoke_function
@@ -142,27 +118,7 @@ async def add_declare_transaction(
     """
     Submit a new class declaration transaction
     """
-    contract_class = declare_transaction["contract_class"]
-    if "abi" not in contract_class:
-        contract_class["abi"] = []
-
-    try:
-        contract_class = decompress_program(declare_transaction, False)[
-            "contract_class"
-        ]
-        contract_class = ContractClass.load(contract_class)
-    except (StarkException, TypeError, MarshmallowError) as ex:
-        raise RpcError(code=50, message="Invalid contract class") from ex
-
-    nonce = declare_transaction.get("nonce")
-    declare_transaction = Declare(
-        contract_class=contract_class,
-        sender_address=int(declare_transaction["sender_address"], 16),
-        nonce=int(nonce, 16) if nonce is not None else 0,
-        version=int(declare_transaction["version"], 16),
-        max_fee=int(declare_transaction["max_fee"], 16),
-        signature=[int(sig, 16) for sig in declare_transaction["signature"]],
-    )
+    declare_transaction = make_declare(declare_transaction)
 
     class_hash, transaction_hash = await state.starknet_wrapper.declare(
         external_tx=declare_transaction
@@ -177,24 +133,7 @@ async def add_deploy_transaction(deploy_transaction: RpcBroadcastedDeployTxn) ->
     """
     Submit a new deploy contract transaction
     """
-    contract_class = deploy_transaction["contract_class"]
-    if "abi" not in contract_class:
-        contract_class["abi"] = []
-
-    try:
-        contract_class = decompress_program(deploy_transaction, False)["contract_class"]
-        contract_class = ContractClass.load(contract_class)
-    except (StarkException, TypeError, MarshmallowError) as ex:
-        raise RpcError(code=50, message="Invalid contract class") from ex
-
-    deploy_transaction = Deploy(
-        contract_address_salt=int(deploy_transaction["contract_address_salt"], 16),
-        constructor_calldata=[
-            int(data, 16) for data in deploy_transaction["constructor_calldata"]
-        ],
-        contract_definition=contract_class,
-        version=int(deploy_transaction["version"], 16),
-    )
+    deploy_transaction = make_deploy(deploy_transaction)
 
     contract_address, transaction_hash = await state.starknet_wrapper.deploy(
         deploy_transaction=deploy_transaction
@@ -205,26 +144,31 @@ async def add_deploy_transaction(deploy_transaction: RpcBroadcastedDeployTxn) ->
     )
 
 
+def make_transaction(txn: RpcBroadcastedTxn) -> AccountTransaction:
+    """
+    Convert RpcBroadcastedTxn to AccountTransaction
+    """
+    txn_type = txn["type"]
+    if txn_type == "INVOKE":
+        return make_invoke_function(txn)
+    if txn_type == "DECLARE":
+        return make_declare(txn)
+    if txn_type == "DEPLOY":
+        return make_deploy(txn)
+    if txn_type == "DEPLOY_ACCOUNT":
+        return make_deploy_account(txn)
+    raise NotImplementedError(f"Unexpected type {txn['type']}.")
+
+
 async def estimate_fee(request: RpcBroadcastedTxn, block_id: BlockId) -> dict:
     """
     Estimate the fee for a given StarkNet transaction
     """
     assert_block_id_is_latest_or_pending(block_id)
-
-    address = (
-        request["contract_address"]
-        if "contract_address" in request
-        else request["sender_address"]
-    )
-
-    if not state.starknet_wrapper.contracts.is_deployed(int(address, 16)):
-        raise RpcError(code=20, message="Contract not found")
-
-    invoke_function = make_invoke_function(request)
-
+    transaction = make_transaction(request)
     try:
         _, fee_response = await state.starknet_wrapper.calculate_trace_and_fee(
-            invoke_function
+            transaction
         )
     except StarkException as ex:
         if "entry_point_selector" in request and (
@@ -232,7 +176,10 @@ async def estimate_fee(request: RpcBroadcastedTxn, block_id: BlockId) -> dict:
             in ex.message
         ):
             raise RpcError(code=21, message="Invalid message selector") from ex
-        if "While handling calldata" in ex.message or "Error at pc=" in ex.message:
+        if "While handling calldata" in ex.message:
             raise RpcError(code=22, message="Invalid call data") from ex
+        if "is not deployed" in ex.message:
+            raise RpcError(code=20, message="Contract not found") from ex
         raise RpcError(code=-1, message=ex.message) from ex
+
     return rpc_fee_estimate(fee_response)

--- a/test/rpc/conftest.py
+++ b/test/rpc/conftest.py
@@ -28,7 +28,6 @@ from starknet_devnet.blueprints.rpc.structures.types import (
 
 DEPLOY_CONTENT = load_file_content("deploy_rpc.json")
 INVOKE_CONTENT = load_file_content("invoke_rpc.json")
-DECLARE_CONTENT = load_file_content("declare.json")
 DECLARE_CONTENT = load_file_content("declare_rpc.json")
 
 

--- a/test/rpc/test_rpc_estimate_fee.py
+++ b/test/rpc/test_rpc_estimate_fee.py
@@ -4,8 +4,9 @@ Tests RPC estimate fee
 
 from __future__ import annotations
 
-from test.account import _get_execute_args, get_nonce
+from test.account import _get_execute_args, get_nonce, _get_signature
 from test.rpc.rpc_utils import rpc_call_background_devnet
+from test.rpc.test_rpc_transactions import pad_zero_entry_points
 from test.shared import (
     PREDEPLOY_ACCOUNT_CLI_ARGS,
     SUPPORTED_RPC_TX_VERSION,
@@ -15,12 +16,20 @@ from test.shared import (
 from test.test_account import deploy_empty_contract
 
 import pytest
+from starkware.starknet.core.os.transaction_hash.transaction_hash import (
+    calculate_declare_transaction_hash,
+)
+from starkware.starknet.definitions.general_config import StarknetChainId
 from starkware.starknet.public.abi import get_selector_from_name
+from starkware.starknet.services.api.contract_class import ContractClass
+from starkware.starknet.services.api.gateway.transaction_utils import decompress_program
 
 from starknet_devnet.blueprints.rpc.structures.payloads import (
     RpcInvokeTransactionV0,
     RpcBroadcastedInvokeTxnV0,
     RpcBroadcastedInvokeTxnV1,
+    RpcContractClass,
+    RpcBroadcastedDeclareTxn,
 )
 from starknet_devnet.blueprints.rpc.utils import rpc_felt
 from starknet_devnet.constants import DEFAULT_GAS_PRICE, LEGACY_RPC_TX_VERSION
@@ -106,6 +115,85 @@ def test_estimate_happy_path():
 
 
 @pytest.mark.usefixtures("run_devnet_in_background")
+def test_estimate_fee_declare_v0(declare_content):
+    """Test estimate_fee with declare transaction"""
+    contract_class = declare_content["contract_class"]
+    pad_zero_entry_points(contract_class["entry_points_by_type"])
+
+    rpc_contract_class = RpcContractClass(
+        program=contract_class["program"],
+        entry_points_by_type=contract_class["entry_points_by_type"],
+        abi=contract_class["abi"],
+    )
+
+    declare_transaction = RpcBroadcastedDeclareTxn(
+        type=declare_content["type"],
+        max_fee=rpc_felt(declare_content["max_fee"]),
+        version=hex(LEGACY_RPC_TX_VERSION),
+        signature=[],
+        nonce=rpc_felt(0),
+        contract_class=rpc_contract_class,
+        sender_address=rpc_felt(1),
+    )
+
+    response = rpc_call_background_devnet(
+        "starknet_estimateFee", {"request": declare_transaction, "block_id": "latest"}
+    )
+
+    common_estimate_response(response)
+
+
+@pytest.mark.usefixtures("run_devnet_in_background")
+@pytest.mark.parametrize(
+    "run_devnet_in_background",
+    [["--gas-price", str(DEFAULT_GAS_PRICE), *PREDEPLOY_ACCOUNT_CLI_ARGS]],
+    indirect=True,
+)
+def test_estimate_fee_declare(declare_content):
+    """Test estimate_fee with declare transaction"""
+    contract_class = declare_content["contract_class"]
+    pad_zero_entry_points(contract_class["entry_points_by_type"])
+
+    rpc_contract_class = RpcContractClass(
+        program=contract_class["program"],
+        entry_points_by_type=contract_class["entry_points_by_type"],
+        abi=contract_class["abi"],
+    )
+
+    contract_class = decompress_program({"contract_class": contract_class}, False)[
+        "contract_class"
+    ]
+    contract_class = ContractClass.load(contract_class)
+
+    nonce = get_nonce(PREDEPLOYED_ACCOUNT_ADDRESS)
+    tx_hash = calculate_declare_transaction_hash(
+        contract_class=contract_class,
+        chain_id=StarknetChainId.TESTNET.value,
+        sender_address=int(PREDEPLOYED_ACCOUNT_ADDRESS, 16),
+        max_fee=0,
+        nonce=nonce,
+        version=SUPPORTED_RPC_TX_VERSION,
+    )
+    signature = _get_signature(tx_hash, PREDEPLOYED_ACCOUNT_PRIVATE_KEY)
+
+    declare_transaction = RpcBroadcastedDeclareTxn(
+        type=declare_content["type"],
+        max_fee=rpc_felt(declare_content["max_fee"]),
+        version=hex(SUPPORTED_RPC_TX_VERSION),
+        signature=[rpc_felt(sig) for sig in signature],
+        nonce=rpc_felt(nonce),
+        contract_class=rpc_contract_class,
+        sender_address=rpc_felt(PREDEPLOYED_ACCOUNT_ADDRESS),
+    )
+
+    response = rpc_call_background_devnet(
+        "starknet_estimateFee", {"request": declare_transaction, "block_id": "latest"}
+    )
+
+    common_estimate_response(response)
+
+
+@pytest.mark.usefixtures("run_devnet_in_background")
 @pytest.mark.parametrize(
     "run_devnet_in_background",
     [["--gas-price", str(DEFAULT_GAS_PRICE), *PREDEPLOY_ACCOUNT_CLI_ARGS]],
@@ -115,7 +203,7 @@ def test_estimate_fee_with_invalid_call_data():
     """Call estimate fee with invalid data on body"""
     contract_address = deploy_empty_contract()["address"]
 
-    calls = [(contract_address, "sum_point_array", [2, 10, 20, 30, 40])]
+    calls = [(contract_address, "sum_point_array", [3, 10, 20, 30, 40])]
     signature, execute_calldata = get_execute_args(calls)
 
     invoke_transaction = RpcBroadcastedInvokeTxnV1(
@@ -125,7 +213,7 @@ def test_estimate_fee_with_invalid_call_data():
         signature=[rpc_felt(sig) for sig in signature],
         nonce=rpc_felt(get_nonce(PREDEPLOYED_ACCOUNT_ADDRESS)),
         sender_address=rpc_felt(PREDEPLOYED_ACCOUNT_ADDRESS),
-        calldata=[rpc_felt(data) for data in execute_calldata][:-1],
+        calldata=[rpc_felt(data) for data in execute_calldata],
     )
     ex = rpc_call_background_devnet(
         "starknet_estimateFee", {"request": invoke_transaction, "block_id": "latest"}


### PR DESCRIPTION
## Usage related changes

- Add support for `estimate_fee` for Declare transactions in RPC, which was omitted in RPC v0.2.0

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Updated the tests
- [x] All tests are passing
