### PR TITLE
Fix for missing l2 to l1 messages

### DIFF
--- a/starknet_devnet/transactions.py
+++ b/starknet_devnet/transactions.py
@@ -81,7 +81,7 @@ class DevnetTransaction:
 
         contract_address = self.execution_info.call_info.contract_address
 
-        for l2_to_l1_message in self.execution_info.call_info.l2_to_l1_messages:
+        for l2_to_l1_message in self.execution_info.get_sorted_l2_to_l1_messages():
             l2_to_l1_messages.append(
                 L2ToL1Message(
                     from_address=contract_address,

--- a/test/test_postman.py
+++ b/test/test_postman.py
@@ -228,9 +228,9 @@ def _l1_l2_message_exchange(web3, l1l2_example_contract, l2_contract_address):
 
     # Check if l2 to l1 message is included in transaction_receipts
     l2_to_l1_block = get_block(parse=True)
-    assert l2_to_l1_block["transaction_receipts"][0]["l2_to_l1_messages"][0]["payload"][
-        2
-    ] == hex(withdraw_amount)
+    l2_to_l1_messages = l2_to_l1_block["transaction_receipts"][0]["l2_to_l1_messages"]
+    l2_to_l1_withdraw_amount = l2_to_l1_messages[0]["payload"][2]
+    assert l2_to_l1_withdraw_amount == hex(withdraw_amount)
 
     balance = web3_call("userBalances", l1l2_example_contract, USER_ID)
     assert balance == withdraw_amount

--- a/test/test_postman.py
+++ b/test/test_postman.py
@@ -216,17 +216,20 @@ def _l1_l2_message_exchange(web3, l1l2_example_contract, l2_contract_address):
     assert balance == 0
 
     # withdraw in l1 and assert contract balance
+    withdraw_amount = 1000
     web3_transact(
         web3,
         "withdraw",
         l1l2_example_contract,
         int(l2_contract_address, base=16),
         USER_ID,
-        1000,
+        withdraw_amount,
     )
+    l2_to_l1_block = get_block(parse=True)
+    assert l2_to_l1_block["transaction_receipts"][0]["l2_to_l1_messages"][0]["payload"][2] == hex(withdraw_amount)
 
     balance = web3_call("userBalances", l1l2_example_contract, USER_ID)
-    assert balance == 1000
+    assert balance == withdraw_amount
 
     # assert l2 contract balance
     l2_balance = call(

--- a/test/test_postman.py
+++ b/test/test_postman.py
@@ -225,8 +225,12 @@ def _l1_l2_message_exchange(web3, l1l2_example_contract, l2_contract_address):
         USER_ID,
         withdraw_amount,
     )
+
+    # Check if l2 to l1 message is included in transaction_receipts
     l2_to_l1_block = get_block(parse=True)
-    assert l2_to_l1_block["transaction_receipts"][0]["l2_to_l1_messages"][0]["payload"][2] == hex(withdraw_amount)
+    assert l2_to_l1_block["transaction_receipts"][0]["l2_to_l1_messages"][0]["payload"][
+        2
+    ] == hex(withdraw_amount)
 
     balance = web3_call("userBalances", l1l2_example_contract, USER_ID)
     assert balance == withdraw_amount


### PR DESCRIPTION
## Usage related changes

- Fix for missing l2 to l1 messages in transaction_receipts

## Development related changes

- test for l2 to l1 messages was added

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
