### PR TITLE
Bugifx for continuation_token when there are no events

### DIFF
--- a/starknet_devnet/blueprints/rpc/misc.py
+++ b/starknet_devnet/blueprints/rpc/misc.py
@@ -93,13 +93,16 @@ async def get_events(
         if block.transaction_receipts:
             events.extend(get_events_from_block(block, address, keys))
 
+    # chunking
     continuation_token = int(continuation_token)
     start_index = continuation_token * chunk_size
     events = events[start_index : start_index + chunk_size]
 
-    return RpcEventsResult(
-        events=events, continuation_token=str(continuation_token + 1)
-    )
+    # continuation_token should be increased only if events are not empty
+    if events:
+        continuation_token = continuation_token + 1
+
+    return RpcEventsResult(events=events, continuation_token=str(continuation_token))
 
 
 async def get_nonce(block_id: BlockId, contract_address: Address) -> Felt:

--- a/test/rpc/test_data/get_events.py
+++ b/test/rpc/test_data/get_events.py
@@ -45,6 +45,13 @@ BLOCK_FROM_0_TO_LATEST_CHUNK_3_CONTINUATION_TOKEN = {
     "continuation_token": "1",
 }
 
+BLOCK_FROM_0_TO_1_CHUNK_3_CONTINUATION_TOKEN = {
+    "from_block": "0",
+    "to_block": "1",
+    "chunk_size": 3,
+    "continuation_token": "0",
+}
+
 BLOCK_FROM_0_TO_LATEST_WITH_ADDRESS = {
     "from_block": "0",
     "to_block": "latest",
@@ -142,6 +149,11 @@ GET_EVENTS_TEST_DATA = [
         [*PREDEPLOY_ACCOUNT_CLI_ARGS],
         BLOCK_FROM_0_TO_LATEST_CHUNK_3_CONTINUATION_TOKEN,
         [FEE_CHARGING_IN_BLOCK_3_EVENT],
+    ),
+    (
+        [*PREDEPLOY_ACCOUNT_CLI_ARGS],
+        BLOCK_FROM_0_TO_1_CHUNK_3_CONTINUATION_TOKEN,
+        [],
     ),
     (
         [*PREDEPLOY_ACCOUNT_CLI_ARGS],

--- a/test/rpc/test_rpc_misc.py
+++ b/test/rpc/test_rpc_misc.py
@@ -175,7 +175,7 @@ def test_get_events(input_data, expected_data):
 
         # increase continuation_token when events are not empty
         if resp["result"]["events"]:
-            expected_continuation_token = expected_continuation_token + 1
+            expected_continuation_token += 1
 
         assert expected_continuation_token == int(resp["result"]["continuation_token"])
 

--- a/test/rpc/test_rpc_misc.py
+++ b/test/rpc/test_rpc_misc.py
@@ -171,9 +171,13 @@ def test_get_events(input_data, expected_data):
         assert str(resp["result"]["events"][i]["data"]) == str(data)
 
     if "continuation_token" in input_data:
-        assert int(input_data["continuation_token"]) + 1 == int(
-            resp["result"]["continuation_token"]
-        )
+        expected_continuation_token = int(input_data["continuation_token"])
+
+        # increase continuation_token when events are not empty
+        if resp["result"]["events"]:
+            expected_continuation_token = expected_continuation_token + 1
+
+        assert expected_continuation_token == int(resp["result"]["continuation_token"])
 
 
 @pytest.mark.usefixtures("devnet_with_account")


### PR DESCRIPTION
## Usage related changes

- bugifx for continuation_token when there was no events

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
