### PR TITLE
Fix for custom_int's in feeder gateway

### DIFF
--- a/starknet_devnet/blueprints/feeder_gateway.py
+++ b/starknet_devnet/blueprints/feeder_gateway.py
@@ -137,7 +137,7 @@ def get_block_traces():
     """Returns the traces of the transactions in the specified block."""
 
     block_hash = request.args.get("blockHash")
-    block_number = validate_int(request.args, "blockNumber")
+    block_number = request.args.get("blockNumber", type=custom_int)
 
     block = _get_block_object(block_hash=block_hash, block_number=block_number)
     block_transaction_traces = _get_block_transaction_traces(block)

--- a/starknet_devnet/blueprints/feeder_gateway.py
+++ b/starknet_devnet/blueprints/feeder_gateway.py
@@ -40,6 +40,18 @@ def validate_request(data: bytes, cls):
         ) from err
 
 
+def validate_int(request_args: MultiDict, attribute: str):
+    """Validate if attribute is int."""
+    try:
+        return int(request_args.get(attribute))
+    except (ValueError) as err:
+        raise StarknetDevnetException(
+            code=StarkErrorCode.MALFORMED_REQUEST,
+            message=str(err),
+            status_code=400,
+        ) from err
+
+
 def _check_block_hash(request_args: MultiDict):
     block_hash = request_args.get("blockHash", type=custom_int)
     if block_hash is not None:
@@ -113,7 +125,7 @@ def get_block():
     """Endpoint for retrieving a block identified by its hash or number."""
 
     block_hash = request.args.get("blockHash")
-    block_number = request.args.get("blockNumber", type=custom_int)
+    block_number = validate_int(request.args, "blockNumber")
 
     block = _get_block_object(block_hash=block_hash, block_number=block_number)
 
@@ -125,7 +137,7 @@ def get_block_traces():
     """Returns the traces of the transactions in the specified block."""
 
     block_hash = request.args.get("blockHash")
-    block_number = request.args.get("blockNumber", type=custom_int)
+    block_number = validate_int(request.args, "blockNumber")
 
     block = _get_block_object(block_hash=block_hash, block_number=block_number)
     block_transaction_traces = _get_block_transaction_traces(block)
@@ -186,7 +198,7 @@ async def get_storage_at():
     _check_block_hash(request.args)
 
     contract_address = request.args.get("contractAddress", type=custom_int)
-    key = request.args.get("key", type=custom_int)
+    key = validate_int(request.args, "key")
 
     storage = await state.starknet_wrapper.get_storage_at(contract_address, key)
     return jsonify(storage)
@@ -259,7 +271,7 @@ def get_state_update():
     """
 
     block_hash = request.args.get("blockHash")
-    block_number = request.args.get("blockNumber", type=custom_int)
+    block_number = validate_int(request.args, "blockNumber")
 
     state_update = state.starknet_wrapper.blocks.get_state_update(
         block_hash=block_hash, block_number=block_number

--- a/starknet_devnet/blueprints/feeder_gateway.py
+++ b/starknet_devnet/blueprints/feeder_gateway.py
@@ -125,7 +125,7 @@ def get_block():
     """Endpoint for retrieving a block identified by its hash or number."""
 
     block_hash = request.args.get("blockHash")
-    block_number = validate_int(request.args, "blockNumber")
+    block_number = request.args.get("blockNumber", type=custom_int)
 
     block = _get_block_object(block_hash=block_hash, block_number=block_number)
 
@@ -271,7 +271,7 @@ def get_state_update():
     """
 
     block_hash = request.args.get("blockHash")
-    block_number = validate_int(request.args, "blockNumber")
+    block_number = request.args.get("blockNumber", type=custom_int)
 
     state_update = state.starknet_wrapper.blocks.get_state_update(
         block_hash=block_hash, block_number=block_number

--- a/test/rpc/test_rpc_transactions.py
+++ b/test/rpc/test_rpc_transactions.py
@@ -382,7 +382,7 @@ def test_add_invoke_transaction():
     storage = gateway_call(
         "get_storage_at",
         contractAddress=contract_address,
-        key=hex(get_storage_var_address("balance")),
+        key=get_storage_var_address("balance"),
     )
 
     assert set(receipt.keys()) == {"transaction_hash"}
@@ -419,7 +419,7 @@ def test_add_invoke_transaction_v0():
     storage = gateway_call(
         "get_storage_at",
         contractAddress=contract_address,
-        key=hex(get_storage_var_address("balance")),
+        key=get_storage_var_address("balance"),
     )
 
     assert set(receipt.keys()) == {"transaction_hash"}


### PR DESCRIPTION
## Usage related changes

- Unification of `get_storage_at` in feeder gateway to be the same as alpha-goerli

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

- `validate_int` function added in feeder gateway

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
