### PR TITLE
Fix dumping on exit

### DIFF
--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -107,6 +107,7 @@ def main():
     except KeyboardInterrupt:
         pass
     finally:
+        # Dump only if process is worker (not main)
         if args.dump_on == DumpOn.EXIT and os.getpid() != pid:
             state.dumper.dump()
             sys.exit(0)

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -2,7 +2,9 @@
 A server exposing Starknet functionalities as API endpoints.
 """
 
-import sys, asyncio, os
+import asyncio
+import os
+import sys
 
 from flask import Flask, jsonify
 from flask_cors import CORS

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -102,13 +102,13 @@ def main():
 
     try:
         print(f" * Listening on http://{args.host}:{args.port}/ (Press CTRL+C to quit)")
-        pid = os.getpid()
+        main_pid = os.getpid()
         GunicornServer(app, args).run()
     except KeyboardInterrupt:
         pass
     finally:
         # Dump only if process is worker (not main)
-        if args.dump_on == DumpOn.EXIT and os.getpid() != pid:
+        if args.dump_on == DumpOn.EXIT and os.getpid() != main_pid:
             state.dumper.dump()
             sys.exit(0)
 

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -2,9 +2,7 @@
 A server exposing Starknet functionalities as API endpoints.
 """
 
-import sys
-import asyncio
-import os
+import sys, asyncio, os
 
 from flask import Flask, jsonify
 from flask_cors import CORS

--- a/starknet_devnet/server.py
+++ b/starknet_devnet/server.py
@@ -4,6 +4,7 @@ A server exposing Starknet functionalities as API endpoints.
 
 import sys
 import asyncio
+import os
 
 from flask import Flask, jsonify
 from flask_cors import CORS
@@ -101,11 +102,12 @@ def main():
 
     try:
         print(f" * Listening on http://{args.host}:{args.port}/ (Press CTRL+C to quit)")
+        pid = os.getpid()
         GunicornServer(app, args).run()
     except KeyboardInterrupt:
         pass
     finally:
-        if args.dump_on == DumpOn.EXIT:
+        if args.dump_on == DumpOn.EXIT and os.getpid() != pid:
             state.dumper.dump()
             sys.exit(0)
 

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -303,6 +303,17 @@ def test_dumping_on_exit():
     )  # send SIGINT because devnet doesn't handle SIGKILL
     assert_dump_present(DUMP_PATH, sleep_seconds=3)
 
+    # load from path after dump
+    devnet_proc = ACTIVE_DEVNET.start(
+        *PREDEPLOY_ACCOUNT_CLI_ARGS, "--load-path", DUMP_PATH
+    )
+    invoke(
+        calls=[(contract_address, "increase_balance", ["1", "2"])],
+        account_address=PREDEPLOYED_ACCOUNT_ADDRESS,
+        private_key=PREDEPLOYED_ACCOUNT_PRIVATE_KEY,
+    )
+    balance_after_invoke = call("get_balance", contract_address, ABI_PATH)
+    assert balance_after_invoke == "33"
 
 def test_invalid_dump_on_option():
     """Test behavior when invalid dump-on is provided."""

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -315,6 +315,7 @@ def test_dumping_on_exit():
     balance_after_invoke = call("get_balance", contract_address, ABI_PATH)
     assert balance_after_invoke == "33"
 
+
 def test_invalid_dump_on_option():
     """Test behavior when invalid dump-on is provided."""
     devnet_proc = ACTIVE_DEVNET.start(


### PR DESCRIPTION
## Usage related changes

- Quick fix for double execution of `dump` function.

## Development related changes

- `test_dumping_on_exit` updated to cover scenario with call after load

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [ ] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
