### PR TITLE
Add `fork_status` endpoint

### DIFF
--- a/page/docs/guide/fork.md
+++ b/page/docs/guide/fork.md
@@ -17,3 +17,21 @@ The `--fork-block` parameter is optional and its value should be the block numbe
 All calls will first try Devnet's state and then fall back to the forking block.
 
 If you are forking another Devnet instance, keep in mind that it doesn't support polling specific blocks, but will always fall back to the currently latest block.
+
+## Get fork status
+```
+GET /fork_status
+```
+
+Response when in fork mode:
+```
+{
+    "url": "https://alpha4.starknet.io",
+    "block": 438839
+}
+```
+
+Response when not in fork mode:
+```
+{}
+```

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -189,3 +189,12 @@ async def create_block():
     """Create empty block"""
     block = await state.starknet_wrapper.create_empty_block()
     return Response(block.dumps(), status=200, mimetype="application/json")
+
+
+@base.route("/fork_status", methods=["GET"])
+async def fork_status():
+    """Get fork status"""
+    config = state.starknet_wrapper.config
+    if config.fork_network:
+        return jsonify({"url": config.fork_network.url, "block": config.fork_block})
+    return jsonify({})


### PR DESCRIPTION
## Usage related changes

- Close #347 
  - Add `/fork_status` endpoint to return fork status


## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
