### PR TITLE
Stop supplying contract_address RPC Deploy

### DIFF
--- a/starknet_devnet/blueprints/rpc/structures/payloads.py
+++ b/starknet_devnet/blueprints/rpc/structures/payloads.py
@@ -328,7 +328,6 @@ def rpc_deploy_transaction(transaction: DeploySpecificInfo) -> RpcDeployTransact
         "class_hash": rpc_felt(transaction.class_hash),
         "version": hex(transaction.version),
         "type": rpc_txn_type(transaction.tx_type.name),
-        "contract_address": rpc_felt(transaction.contract_address),
         "contract_address_salt": rpc_felt(transaction.contract_address_salt),
         "constructor_calldata": [
             rpc_felt(data) for data in transaction.constructor_calldata
@@ -432,7 +431,7 @@ def make_invoke_function(invoke_transaction: RpcBroadcastedInvokeTxn) -> InvokeF
 
 def make_declare(declare_transaction: RpcBroadcastedDeclareTxn) -> Declare:
     """
-    Convert RpcDeclareTransaction to Declare
+    Convert RpcBroadcastedDeclareTxn to Declare
     """
     contract_class = declare_transaction["contract_class"]
     if "abi" not in contract_class:
@@ -458,9 +457,9 @@ def make_declare(declare_transaction: RpcBroadcastedDeclareTxn) -> Declare:
     return declare_tx
 
 
-def make_deploy(deploy_transaction: RpcDeployTransaction) -> Deploy:
+def make_deploy(deploy_transaction: RpcBroadcastedDeployTxn) -> Deploy:
     """
-    Convert RpcDeployTransaction to Deploy
+    Convert RpcBroadcastedDeployTxn to Deploy
     """
     contract_class = deploy_transaction["contract_class"]
     if "abi" not in contract_class:
@@ -484,10 +483,10 @@ def make_deploy(deploy_transaction: RpcDeployTransaction) -> Deploy:
 
 
 def make_deploy_account(
-    deploy_account_transaction: RpcDeployAccountTransaction,
+    deploy_account_transaction: RpcBroadcastedDeployAccountTxn,
 ) -> DeployAccount:
     """
-    Convert RpcDeployAccountTransaction to DeployAccount
+    Convert RpcBroadcastedDeployAccountTxn to DeployAccount
     """
     deploy_account_tx = DeployAccount(
         class_hash=int(deploy_account_transaction["class_hash"], 16),

--- a/test/rpc/test_rpc_blocks.py
+++ b/test/rpc/test_rpc_blocks.py
@@ -89,7 +89,6 @@ def test_get_block_with_txs(gateway_block, block_id):
                 "constructor_calldata": [
                     rpc_felt(data) for data in block_tx["constructor_calldata"]
                 ],
-                "contract_address": rpc_felt(block_tx["contract_address"]),
                 "contract_address_salt": rpc_felt(block_tx["contract_address_salt"]),
                 "transaction_hash": rpc_felt(block_tx["transaction_hash"]),
                 "type": rpc_txn_type(block_tx["type"]),

--- a/test/rpc/test_rpc_transactions.py
+++ b/test/rpc/test_rpc_transactions.py
@@ -78,7 +78,6 @@ def test_get_transaction_by_hash_deploy(deploy_info):
     block = get_block_with_transaction(deploy_info["transaction_hash"])
     block_tx = block["transactions"][0]
     transaction_hash: str = deploy_info["transaction_hash"]
-    contract_address: str = deploy_info["address"]
 
     resp = rpc_call(
         "starknet_getTransactionByHash",
@@ -91,7 +90,6 @@ def test_get_transaction_by_hash_deploy(deploy_info):
         "class_hash": rpc_felt(block_tx["class_hash"]),
         "version": hex(SUPPORTED_RPC_TX_VERSION),
         "type": rpc_txn_type(block_tx["type"]),
-        "contract_address": rpc_felt(contract_address),
         "contract_address_salt": rpc_felt(block_tx["contract_address_salt"]),
         "constructor_calldata": ["0x045"],
     }
@@ -210,7 +208,6 @@ def test_get_transaction_by_block_id_and_index(deploy_info):
     block = get_block_with_transaction(deploy_info["transaction_hash"])
     block_tx = block["transactions"][0]
     transaction_hash: str = deploy_info["transaction_hash"]
-    contract_address: str = deploy_info["address"]
     block_number: str = block["block_number"]
     index: int = 0
 
@@ -230,7 +227,6 @@ def test_get_transaction_by_block_id_and_index(deploy_info):
         "constructor_calldata": [
             rpc_felt(tx) for tx in block_tx["constructor_calldata"]
         ],
-        "contract_address": rpc_felt(contract_address),
         "contract_address_salt": rpc_felt(block_tx["contract_address_salt"]),
         "transaction_hash": rpc_felt(transaction_hash),
         "type": rpc_txn_type(block_tx["type"]),


### PR DESCRIPTION
Remove `"contract_address"` field from `rpc_deploy_transaction` function.

Change a few wrong types (logic is good, only the type names).