### PR TITLE
Support specifying chain ID

### DIFF
--- a/page/docs/guide/run.md
+++ b/page/docs/guide/run.md
@@ -44,7 +44,7 @@ optional arguments:
   --fork-block FORK_BLOCK
                         Specify the block number where the --fork-network is forked; defaults to latest
   --chain_id CHAIN_ID
-                        Specify the chain id as string, MAINNET or TESTNET
+                        Specify the chain id as string: ['MAINNET', 'TESTNET']
 ```
 
 You can run `starknet-devnet` in a separate shell, or you can run it in background with `starknet-devnet &`.

--- a/page/docs/guide/run.md
+++ b/page/docs/guide/run.md
@@ -10,6 +10,7 @@ Installing the package adds the `starknet-devnet` command.
 usage: starknet-devnet [-h] [-v] [--host HOST] [--port PORT] [--load-path LOAD_PATH] [--dump-path DUMP_PATH] [--dump-on DUMP_ON] [--lite-mode] [--accounts ACCOUNTS]
                        [--initial-balance INITIAL_BALANCE] [--seed SEED] [--hide-predeployed-accounts] [--start-time START_TIME] [--gas-price GAS_PRICE] [--timeout TIMEOUT]
                        [--account-class ACCOUNT_CLASS] [--fork-network FORK_NETWORK] [--fork-block FORK_BLOCK]
+                       [--chain_id CHAIN_ID]
 
 Run a local instance of StarkNet Devnet
 
@@ -42,6 +43,8 @@ optional arguments:
                         Specify the network to fork: can be a URL (e.g. https://alpha-mainnet.starknet.io) or network name (valid names: alpha-goerli, alpha-goerli2, alpha-mainnet)
   --fork-block FORK_BLOCK
                         Specify the block number where the --fork-network is forked; defaults to latest
+  --chain_id CHAIN_ID
+                        Specify the chain id as string, MAINNET or TESTNET
 ```
 
 You can run `starknet-devnet` in a separate shell, or you can run it in background with `starknet-devnet &`.

--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -276,6 +276,10 @@ def parse_args(raw_args: List[str]):
         type=_fork_block,
         help="Specify the block number where the --fork-network is forked; defaults to latest",
     )
+    parser.add_argument(
+        "--chain-id",
+        help="Specify the chain id as string, MAINNET or TESTNET",
+    ) 
 
     parsed_args = parser.parse_args(raw_args)
     if parsed_args.dump_on and not parsed_args.dump_path:
@@ -311,3 +315,4 @@ class DevnetConfig:
         self.hide_predeployed_accounts = self.args.hide_predeployed_accounts
         self.fork_network = self.args.fork_network
         self.fork_block = self.args.fork_block
+        self.chain_id = self.args.chain_id

--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -41,6 +41,7 @@ NETWORK_TO_URL = {
     "alpha-mainnet": "https://alpha-mainnet.starknet.io",
 }
 NETWORK_NAMES = ", ".join(NETWORK_TO_URL.keys())
+CHAIN_IDS = ", ".join([member.name for member in StarknetChainId])
 
 
 def _fork_network(network_id: str):
@@ -69,13 +70,11 @@ def _fork_block(specifier: str):
 
 def _chain_id(chain_id: str):
     """Parse chain id.'"""
-    chain_ids = [member.name for member in StarknetChainId]
-
     try:
-        chain_id = StarknetChainId[chain_id].name
+        chain_id = StarknetChainId[chain_id]
     except KeyError:
         sys.exit(
-            f"Error: The value of --chain_id must be in {chain_ids}, got: {chain_id}"
+            f"Error: The value of --chain_id must be in {{{CHAIN_IDS}}}, got: {chain_id}"
         )
 
     return chain_id
@@ -294,8 +293,8 @@ def parse_args(raw_args: List[str]):
     parser.add_argument(
         "--chain-id",
         type=_chain_id,
-        default=StarknetChainId.TESTNET.name,
-        help=f"Specify the chain id as string: {[member.name for member in StarknetChainId]}",
+        default=StarknetChainId.TESTNET,
+        help=f"Specify the chain id as string: {{{CHAIN_IDS}}}",
     )
 
     parsed_args = parser.parse_args(raw_args)

--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -74,7 +74,7 @@ def _chain_id(chain_id: str):
     try:
         chain_id = StarknetChainId[chain_id].name
     except KeyError:
-        sys.exit(f"The value of --chain_id must be in {chain_ids}, got: {chain_id}")
+        sys.exit(f"Error: The value of --chain_id must be in {chain_ids}, got: {chain_id}")
 
     return chain_id
 

--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -279,7 +279,7 @@ def parse_args(raw_args: List[str]):
     parser.add_argument(
         "--chain-id",
         help="Specify the chain id as string, MAINNET or TESTNET",
-    ) 
+    )
 
     parsed_args = parser.parse_args(raw_args)
     if parsed_args.dump_on and not parsed_args.dump_path:

--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -14,11 +14,11 @@ from marshmallow.exceptions import ValidationError
 from services.external_api.client import BadRequest, RetryConfig
 from starkware.python.utils import to_bytes
 from starkware.starknet.core.os.class_hash import compute_class_hash
+from starkware.starknet.definitions.general_config import StarknetChainId
 from starkware.starknet.services.api.contract_class import ContractClass
 from starkware.starknet.services.api.feeder_gateway.feeder_gateway_client import (
     FeederGatewayClient,
 )
-from starkware.starknet.definitions.general_config import StarknetChainId
 
 from . import __version__
 from .constants import (
@@ -66,18 +66,18 @@ def _fork_block(specifier: str):
 
     return parsed
 
+
 def _chain_id(chain_id: str):
     """Parse chain id.'"""
     chain_ids = [member.name for member in StarknetChainId]
 
     try:
         chain_id = StarknetChainId[chain_id].name
-    except (KeyError):
-        sys.exit(
-            f"The value of --chain_id must be in {chain_ids}, got: {chain_id}"
-        )
+    except KeyError:
+        sys.exit(f"The value of --chain_id must be in {chain_ids}, got: {chain_id}")
 
     return chain_id
+
 
 class DumpOn(Enum):
     """Enumerate possible dumping frequencies."""

--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -18,6 +18,7 @@ from starkware.starknet.services.api.contract_class import ContractClass
 from starkware.starknet.services.api.feeder_gateway.feeder_gateway_client import (
     FeederGatewayClient,
 )
+from starkware.starknet.definitions.general_config import StarknetChainId
 
 from . import __version__
 from .constants import (
@@ -65,6 +66,18 @@ def _fork_block(specifier: str):
 
     return parsed
 
+def _chain_id(chain_id: str):
+    """Parse chain id.'"""
+    chain_ids = [member.name for member in StarknetChainId]
+
+    try:
+        chain_id = StarknetChainId[chain_id].name
+    except (KeyError):
+        sys.exit(
+            f"The value of --chain_id must be in {chain_ids}, got: {chain_id}"
+        )
+
+    return chain_id
 
 class DumpOn(Enum):
     """Enumerate possible dumping frequencies."""
@@ -278,6 +291,8 @@ def parse_args(raw_args: List[str]):
     )
     parser.add_argument(
         "--chain-id",
+        type=_chain_id,
+        default=StarknetChainId.TESTNET.name,
         help="Specify the chain id as string, MAINNET or TESTNET",
     )
 

--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -293,7 +293,7 @@ def parse_args(raw_args: List[str]):
         "--chain-id",
         type=_chain_id,
         default=StarknetChainId.TESTNET.name,
-        help="Specify the chain id as string, MAINNET or TESTNET",
+        help=f"Specify the chain id as string: {[member.name for member in StarknetChainId]}",
     )
 
     parsed_args = parser.parse_args(raw_args)

--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -74,7 +74,9 @@ def _chain_id(chain_id: str):
     try:
         chain_id = StarknetChainId[chain_id].name
     except KeyError:
-        sys.exit(f"Error: The value of --chain_id must be in {chain_ids}, got: {chain_id}")
+        sys.exit(
+            f"Error: The value of --chain_id must be in {chain_ids}, got: {chain_id}"
+        )
 
     return chain_id
 

--- a/starknet_devnet/forked_state.py
+++ b/starknet_devnet/forked_state.py
@@ -89,7 +89,7 @@ class ForkedStateReader(StateReader):
 
 
 def get_forked_starknet(
-    feeder_gateway_client: FeederGatewayClient, block_number: int, gas_price: int
+    feeder_gateway_client: FeederGatewayClient, block_number: int, gas_price: int, chain_id: str
 ) -> Starknet:
     """Return a forked Starknet"""
     state_reader = ForkedStateReader(

--- a/starknet_devnet/forked_state.py
+++ b/starknet_devnet/forked_state.py
@@ -17,7 +17,7 @@ from starkware.starknet.testing.state import StarknetState
 from starkware.starkware_utils.error_handling import StarkException
 
 from .block_info_generator import now
-from .general_config import build_config
+from .general_config import build_devnet_general_config
 
 
 def is_originally_starknet_exception(exc: BadRequest):
@@ -110,6 +110,6 @@ def get_forked_starknet(
                 state_reader=state_reader,
                 contract_class_cache={},
             ),
-            general_config=build_config(chain_id),
+            general_config=build_devnet_general_config(chain_id),
         )
     )

--- a/starknet_devnet/forked_state.py
+++ b/starknet_devnet/forked_state.py
@@ -17,7 +17,7 @@ from starkware.starknet.testing.state import StarknetState
 from starkware.starkware_utils.error_handling import StarkException
 
 from .block_info_generator import now
-from .general_config import DEFAULT_GENERAL_CONFIG
+from .general_config import build_general_config_chain_id
 
 
 def is_originally_starknet_exception(exc: BadRequest):
@@ -89,7 +89,10 @@ class ForkedStateReader(StateReader):
 
 
 def get_forked_starknet(
-    feeder_gateway_client: FeederGatewayClient, block_number: int, gas_price: int, chain_id: str
+    feeder_gateway_client: FeederGatewayClient,
+    block_number: int,
+    gas_price: int,
+    chain_id: str,
 ) -> Starknet:
     """Return a forked Starknet"""
     state_reader = ForkedStateReader(
@@ -107,6 +110,6 @@ def get_forked_starknet(
                 state_reader=state_reader,
                 contract_class_cache={},
             ),
-            general_config=DEFAULT_GENERAL_CONFIG,
+            general_config=build_general_config_chain_id(chain_id),
         )
     )

--- a/starknet_devnet/forked_state.py
+++ b/starknet_devnet/forked_state.py
@@ -89,7 +89,10 @@ class ForkedStateReader(StateReader):
 
 
 def get_forked_starknet(
-    feeder_gateway_client: FeederGatewayClient, block_number: int, gas_price: int, chain_id: str
+    feeder_gateway_client: FeederGatewayClient,
+    block_number: int,
+    gas_price: int,
+    chain_id: str,
 ) -> Starknet:
     """Return a forked Starknet"""
     state_reader = ForkedStateReader(

--- a/starknet_devnet/forked_state.py
+++ b/starknet_devnet/forked_state.py
@@ -8,6 +8,7 @@ from starkware.python.utils import to_bytes
 from starkware.starknet.business_logic.state.state import BlockInfo, CachedState
 from starkware.starknet.business_logic.state.state_api import StateReader
 from starkware.starknet.definitions.constants import UNINITIALIZED_CLASS_HASH
+from starkware.starknet.definitions.general_config import StarknetChainId
 from starkware.starknet.services.api.contract_class import ContractClass
 from starkware.starknet.services.api.feeder_gateway.feeder_gateway_client import (
     FeederGatewayClient,
@@ -92,7 +93,7 @@ def get_forked_starknet(
     feeder_gateway_client: FeederGatewayClient,
     block_number: int,
     gas_price: int,
-    chain_id: str,
+    chain_id: StarknetChainId,
 ) -> Starknet:
     """Return a forked Starknet"""
     state_reader = ForkedStateReader(

--- a/starknet_devnet/forked_state.py
+++ b/starknet_devnet/forked_state.py
@@ -17,7 +17,7 @@ from starkware.starknet.testing.state import StarknetState
 from starkware.starkware_utils.error_handling import StarkException
 
 from .block_info_generator import now
-from .general_config import build_general_config_chain_id
+from .general_config import build_config
 
 
 def is_originally_starknet_exception(exc: BadRequest):
@@ -89,10 +89,7 @@ class ForkedStateReader(StateReader):
 
 
 def get_forked_starknet(
-    feeder_gateway_client: FeederGatewayClient,
-    block_number: int,
-    gas_price: int,
-    chain_id: str,
+    feeder_gateway_client: FeederGatewayClient, block_number: int, gas_price: int, chain_id: str
 ) -> Starknet:
     """Return a forked Starknet"""
     state_reader = ForkedStateReader(
@@ -110,6 +107,6 @@ def get_forked_starknet(
                 state_reader=state_reader,
                 contract_class_cache={},
             ),
-            general_config=build_general_config_chain_id(chain_id),
+            general_config=build_config(chain_id),
         )
     )

--- a/starknet_devnet/general_config.py
+++ b/starknet_devnet/general_config.py
@@ -2,6 +2,8 @@
 Contains general_config generation functionalities.
 """
 from enum import Enum
+
+from starkware.python.utils import from_bytes
 from starkware.starknet.definitions import constants
 from starkware.starknet.definitions.general_config import (
     DEFAULT_CHAIN_ID,
@@ -14,18 +16,17 @@ from starkware.starknet.definitions.general_config import (
 
 from .constants import SUPPORTED_TX_VERSION
 from .fee_token import FeeToken
-from starkware.python.utils import from_bytes
+
 
 class StarknetChainId(Enum):
+    """Chain id enum used for mapping."""
+
     MAINNET = from_bytes(b"SN_MAIN")
     TESTNET = from_bytes(b"SN_GOERLI")
 
-def build_general_config_chain_id(chain_id):
 
-    # Just for tests - remove later
-    print("StarknetChainId[chain_id].name if chain_id else DEFAULT_CHAIN_ID.name")
-    print(StarknetChainId[chain_id].name if chain_id else DEFAULT_CHAIN_ID.name)
-    
+def build_general_config_chain_id(chain_id):
+    """General config build with chain id argument."""
     return build_general_config(
         {
             "cairo_resource_fee_weights": {
@@ -38,7 +39,9 @@ def build_general_config_chain_id(chain_id):
             "min_gas_price": DEFAULT_GAS_PRICE,
             "sequencer_address": hex(DEFAULT_SEQUENCER_ADDRESS),
             "starknet_os_config": {
-                "chain_id": StarknetChainId[chain_id].name if chain_id else DEFAULT_CHAIN_ID.name, 
+                "chain_id": StarknetChainId[chain_id].name
+                if chain_id
+                else DEFAULT_CHAIN_ID.name,
                 "fee_token_address": hex(FeeToken.ADDRESS),
             },
             "tx_version": SUPPORTED_TX_VERSION,
@@ -47,24 +50,5 @@ def build_general_config_chain_id(chain_id):
         }
     )
 
-# Remove or unify later
-DEFAULT_GENERAL_CONFIG = build_general_config(
-    {
-        "cairo_resource_fee_weights": {
-            "n_steps": constants.N_STEPS_FEE_WEIGHT,
-        },
-        "contract_storage_commitment_tree_height": constants.CONTRACT_STATES_COMMITMENT_TREE_HEIGHT,
-        "event_commitment_tree_height": constants.EVENT_COMMITMENT_TREE_HEIGHT,
-        "global_state_commitment_tree_height": constants.CONTRACT_ADDRESS_BITS,
-        "invoke_tx_max_n_steps": DEFAULT_MAX_STEPS,
-        "min_gas_price": DEFAULT_GAS_PRICE,
-        "sequencer_address": hex(DEFAULT_SEQUENCER_ADDRESS),
-        "starknet_os_config": {
-            "chain_id": DEFAULT_CHAIN_ID.name,
-            "fee_token_address": hex(FeeToken.ADDRESS),
-        },
-        "tx_version": SUPPORTED_TX_VERSION,
-        "tx_commitment_tree_height": constants.TRANSACTION_COMMITMENT_TREE_HEIGHT,
-        "validate_max_n_steps": DEFAULT_VALIDATE_MAX_STEPS,
-    }
-)
+
+DEFAULT_GENERAL_CONFIG = build_general_config_chain_id("")

--- a/starknet_devnet/general_config.py
+++ b/starknet_devnet/general_config.py
@@ -25,7 +25,7 @@ class StarknetChainId(Enum):
     TESTNET = from_bytes(b"SN_GOERLI")
 
 
-def build_general_config_chain_id(chain_id):
+def build_config(chain_id):
     """General config build with chain id argument."""
     return build_general_config(
         {
@@ -51,4 +51,4 @@ def build_general_config_chain_id(chain_id):
     )
 
 
-DEFAULT_GENERAL_CONFIG = build_general_config_chain_id("")
+DEFAULT_GENERAL_CONFIG = build_config("")

--- a/starknet_devnet/general_config.py
+++ b/starknet_devnet/general_config.py
@@ -14,7 +14,7 @@ from starkware.starknet.definitions.general_config import (
 from .constants import SUPPORTED_TX_VERSION
 from .fee_token import FeeToken
 
-def build_config(chain_id=""):
+def build_devnet_general_config(chain_id=""):
     """General config build with chain id argument."""
     return build_general_config(
         {
@@ -40,4 +40,4 @@ def build_config(chain_id=""):
     )
 
 
-DEFAULT_GENERAL_CONFIG = build_config()
+DEFAULT_GENERAL_CONFIG = build_devnet_general_config()

--- a/starknet_devnet/general_config.py
+++ b/starknet_devnet/general_config.py
@@ -14,7 +14,7 @@ from starkware.starknet.definitions.general_config import (
 from .constants import SUPPORTED_TX_VERSION
 from .fee_token import FeeToken
 
-def build_devnet_general_config(chain_id=""):
+def build_devnet_general_config(chain_id):
     """General config build with chain id argument."""
     return build_general_config(
         {
@@ -28,9 +28,7 @@ def build_devnet_general_config(chain_id=""):
             "min_gas_price": DEFAULT_GAS_PRICE,
             "sequencer_address": hex(DEFAULT_SEQUENCER_ADDRESS),
             "starknet_os_config": {
-                "chain_id": StarknetChainId[chain_id].name
-                if chain_id
-                else StarknetChainId.TESTNET.name,
+                "chain_id": StarknetChainId[chain_id].name,
                 "fee_token_address": hex(FeeToken.ADDRESS),
             },
             "tx_version": SUPPORTED_TX_VERSION,
@@ -40,4 +38,4 @@ def build_devnet_general_config(chain_id=""):
     )
 
 
-DEFAULT_GENERAL_CONFIG = build_devnet_general_config()
+DEFAULT_GENERAL_CONFIG = build_devnet_general_config(StarknetChainId.TESTNET.name)

--- a/starknet_devnet/general_config.py
+++ b/starknet_devnet/general_config.py
@@ -7,12 +7,13 @@ from starkware.starknet.definitions.general_config import (
     DEFAULT_MAX_STEPS,
     DEFAULT_SEQUENCER_ADDRESS,
     DEFAULT_VALIDATE_MAX_STEPS,
-    build_general_config,
     StarknetChainId,
+    build_general_config,
 )
 
 from .constants import SUPPORTED_TX_VERSION
 from .fee_token import FeeToken
+
 
 def build_devnet_general_config(chain_id):
     """General config build with chain id argument."""

--- a/starknet_devnet/general_config.py
+++ b/starknet_devnet/general_config.py
@@ -6,7 +6,6 @@ from enum import Enum
 from starkware.python.utils import from_bytes
 from starkware.starknet.definitions import constants
 from starkware.starknet.definitions.general_config import (
-    DEFAULT_CHAIN_ID,
     DEFAULT_GAS_PRICE,
     DEFAULT_MAX_STEPS,
     DEFAULT_SEQUENCER_ADDRESS,
@@ -41,7 +40,7 @@ def build_config(chain_id):
             "starknet_os_config": {
                 "chain_id": StarknetChainId[chain_id].name
                 if chain_id
-                else DEFAULT_CHAIN_ID.name,
+                else StarknetChainId.TESTNET.name,
                 "fee_token_address": hex(FeeToken.ADDRESS),
             },
             "tx_version": SUPPORTED_TX_VERSION,

--- a/starknet_devnet/general_config.py
+++ b/starknet_devnet/general_config.py
@@ -15,7 +15,7 @@ from .constants import SUPPORTED_TX_VERSION
 from .fee_token import FeeToken
 
 
-def build_devnet_general_config(chain_id: str):
+def build_devnet_general_config(chain_id: StarknetChainId):
     """General config build with chain id argument."""
     return build_general_config(
         {
@@ -29,7 +29,7 @@ def build_devnet_general_config(chain_id: str):
             "min_gas_price": DEFAULT_GAS_PRICE,
             "sequencer_address": hex(DEFAULT_SEQUENCER_ADDRESS),
             "starknet_os_config": {
-                "chain_id": StarknetChainId[chain_id].name,
+                "chain_id": chain_id.name,
                 "fee_token_address": hex(FeeToken.ADDRESS),
             },
             "tx_version": SUPPORTED_TX_VERSION,
@@ -39,4 +39,4 @@ def build_devnet_general_config(chain_id: str):
     )
 
 
-DEFAULT_GENERAL_CONFIG = build_devnet_general_config(StarknetChainId.TESTNET.name)
+DEFAULT_GENERAL_CONFIG = build_devnet_general_config(StarknetChainId.TESTNET)

--- a/starknet_devnet/general_config.py
+++ b/starknet_devnet/general_config.py
@@ -1,7 +1,7 @@
 """
 Contains general_config generation functionalities.
 """
-
+from enum import Enum
 from starkware.starknet.definitions import constants
 from starkware.starknet.definitions.general_config import (
     DEFAULT_CHAIN_ID,
@@ -14,7 +14,40 @@ from starkware.starknet.definitions.general_config import (
 
 from .constants import SUPPORTED_TX_VERSION
 from .fee_token import FeeToken
+from starkware.python.utils import from_bytes
 
+class StarknetChainId(Enum):
+    MAINNET = from_bytes(b"SN_MAIN")
+    TESTNET = from_bytes(b"SN_GOERLI")
+
+def build_general_config_chain_id(chain_id):
+
+    # Just for tests - remove later
+    print("StarknetChainId[chain_id].name if chain_id else DEFAULT_CHAIN_ID.name")
+    print(StarknetChainId[chain_id].name if chain_id else DEFAULT_CHAIN_ID.name)
+    
+    return build_general_config(
+        {
+            "cairo_resource_fee_weights": {
+                "n_steps": constants.N_STEPS_FEE_WEIGHT,
+            },
+            "contract_storage_commitment_tree_height": constants.CONTRACT_STATES_COMMITMENT_TREE_HEIGHT,
+            "event_commitment_tree_height": constants.EVENT_COMMITMENT_TREE_HEIGHT,
+            "global_state_commitment_tree_height": constants.CONTRACT_ADDRESS_BITS,
+            "invoke_tx_max_n_steps": DEFAULT_MAX_STEPS,
+            "min_gas_price": DEFAULT_GAS_PRICE,
+            "sequencer_address": hex(DEFAULT_SEQUENCER_ADDRESS),
+            "starknet_os_config": {
+                "chain_id": StarknetChainId[chain_id].name if chain_id else DEFAULT_CHAIN_ID.name, 
+                "fee_token_address": hex(FeeToken.ADDRESS),
+            },
+            "tx_version": SUPPORTED_TX_VERSION,
+            "tx_commitment_tree_height": constants.TRANSACTION_COMMITMENT_TREE_HEIGHT,
+            "validate_max_n_steps": DEFAULT_VALIDATE_MAX_STEPS,
+        }
+    )
+
+# Remove or unify later
 DEFAULT_GENERAL_CONFIG = build_general_config(
     {
         "cairo_resource_fee_weights": {

--- a/starknet_devnet/general_config.py
+++ b/starknet_devnet/general_config.py
@@ -24,7 +24,7 @@ class StarknetChainId(Enum):
     TESTNET = from_bytes(b"SN_GOERLI")
 
 
-def build_config(chain_id):
+def build_config(chain_id=""):
     """General config build with chain id argument."""
     return build_general_config(
         {
@@ -50,4 +50,4 @@ def build_config(chain_id):
     )
 
 
-DEFAULT_GENERAL_CONFIG = build_config("")
+DEFAULT_GENERAL_CONFIG = build_config()

--- a/starknet_devnet/general_config.py
+++ b/starknet_devnet/general_config.py
@@ -15,7 +15,7 @@ from .constants import SUPPORTED_TX_VERSION
 from .fee_token import FeeToken
 
 
-def build_devnet_general_config(chain_id):
+def build_devnet_general_config(chain_id: str):
     """General config build with chain id argument."""
     return build_general_config(
         {

--- a/starknet_devnet/general_config.py
+++ b/starknet_devnet/general_config.py
@@ -1,9 +1,6 @@
 """
 Contains general_config generation functionalities.
 """
-from enum import Enum
-
-from starkware.python.utils import from_bytes
 from starkware.starknet.definitions import constants
 from starkware.starknet.definitions.general_config import (
     DEFAULT_GAS_PRICE,
@@ -11,18 +8,11 @@ from starkware.starknet.definitions.general_config import (
     DEFAULT_SEQUENCER_ADDRESS,
     DEFAULT_VALIDATE_MAX_STEPS,
     build_general_config,
+    StarknetChainId,
 )
 
 from .constants import SUPPORTED_TX_VERSION
 from .fee_token import FeeToken
-
-
-class StarknetChainId(Enum):
-    """Chain id enum used for mapping."""
-
-    MAINNET = from_bytes(b"SN_MAIN")
-    TESTNET = from_bytes(b"SN_GOERLI")
-
 
 def build_config(chain_id=""):
     """General config build with chain id argument."""

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -156,7 +156,7 @@ class StarknetWrapper:
                     feeder_gateway_client=self.config.fork_network,
                     block_number=self.config.fork_block,
                     gas_price=self.block_info_generator.gas_price,
-                    chain_id=self.config.chain_id
+                    chain_id=self.config.chain_id,
                 )
             else:
                 self.starknet = await Starknet.empty(

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -60,7 +60,7 @@ from .constants import DUMMY_STATE_ROOT, OZ_ACCOUNT_CLASS_HASH
 from .devnet_config import DevnetConfig
 from .fee_token import FeeToken
 from .forked_state import get_forked_starknet
-from .general_config import build_general_config_chain_id
+from .general_config import build_config
 from .origin import ForkedOrigin, NullOrigin
 from .postman_wrapper import DevnetL1L2
 from .sequencer_api_utils import InternalInvokeFunctionForSimulate
@@ -156,11 +156,11 @@ class StarknetWrapper:
                     feeder_gateway_client=self.config.fork_network,
                     block_number=self.config.fork_block,
                     gas_price=self.block_info_generator.gas_price,
-                    chain_id=self.config.chain_id,
+                    chain_id=self.config.chain_id
                 )
             else:
                 self.starknet = await Starknet.empty(
-                    general_config=build_general_config_chain_id(self.config.chain_id)
+                    general_config=build_config(self.config.chain_id)
                 )
 
         return self.starknet

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -26,7 +26,6 @@ from starkware.starknet.core.os.transaction_hash.transaction_hash import (
     calculate_deploy_transaction_hash,
 )
 from starkware.starknet.definitions.error_codes import StarknetErrorCode
-from starkware.starknet.definitions.general_config import StarknetChainId
 from starkware.starknet.services.api.contract_class import ContractClass, EntryPointType
 from starkware.starknet.services.api.feeder_gateway.request_objects import (
     CallFunction,

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -60,7 +60,7 @@ from .constants import DUMMY_STATE_ROOT, OZ_ACCOUNT_CLASS_HASH
 from .devnet_config import DevnetConfig
 from .fee_token import FeeToken
 from .forked_state import get_forked_starknet
-from .general_config import build_config
+from .general_config import build_devnet_general_config
 from .origin import ForkedOrigin, NullOrigin
 from .postman_wrapper import DevnetL1L2
 from .sequencer_api_utils import InternalInvokeFunctionForSimulate
@@ -160,7 +160,7 @@ class StarknetWrapper:
                 )
             else:
                 self.starknet = await Starknet.empty(
-                    general_config=build_config(self.config.chain_id)
+                    general_config=build_devnet_general_config(self.config.chain_id)
                 )
 
         return self.starknet

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -60,7 +60,7 @@ from .constants import DUMMY_STATE_ROOT, OZ_ACCOUNT_CLASS_HASH
 from .devnet_config import DevnetConfig
 from .fee_token import FeeToken
 from .forked_state import get_forked_starknet
-from .general_config import DEFAULT_GENERAL_CONFIG
+from .general_config import build_general_config_chain_id
 from .origin import ForkedOrigin, NullOrigin
 from .postman_wrapper import DevnetL1L2
 from .sequencer_api_utils import InternalInvokeFunctionForSimulate
@@ -156,10 +156,11 @@ class StarknetWrapper:
                     feeder_gateway_client=self.config.fork_network,
                     block_number=self.config.fork_block,
                     gas_price=self.block_info_generator.gas_price,
+                    chain_id=self.config.chain_id
                 )
             else:
                 self.starknet = await Starknet.empty(
-                    general_config=DEFAULT_GENERAL_CONFIG
+                    general_config=build_general_config_chain_id(self.config.chain_id)
                 )
 
         return self.starknet

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -26,6 +26,7 @@ from starkware.starknet.core.os.transaction_hash.transaction_hash import (
     calculate_deploy_transaction_hash,
 )
 from starkware.starknet.definitions.error_codes import StarknetErrorCode
+from starkware.starknet.definitions.general_config import StarknetChainId
 from starkware.starknet.services.api.contract_class import ContractClass, EntryPointType
 from starkware.starknet.services.api.feeder_gateway.request_objects import (
     CallFunction,
@@ -156,11 +157,13 @@ class StarknetWrapper:
                     feeder_gateway_client=self.config.fork_network,
                     block_number=self.config.fork_block,
                     gas_price=self.block_info_generator.gas_price,
-                    chain_id=self.config.chain_id,
+                    chain_id=StarknetChainId[self.config.chain_id],
                 )
             else:
                 self.starknet = await Starknet.empty(
-                    general_config=build_devnet_general_config(self.config.chain_id)
+                    general_config=build_devnet_general_config(
+                        StarknetChainId[self.config.chain_id]
+                    )
                 )
 
         return self.starknet

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -157,13 +157,11 @@ class StarknetWrapper:
                     feeder_gateway_client=self.config.fork_network,
                     block_number=self.config.fork_block,
                     gas_price=self.block_info_generator.gas_price,
-                    chain_id=StarknetChainId[self.config.chain_id],
+                    chain_id=self.config.chain_id,
                 )
             else:
                 self.starknet = await Starknet.empty(
-                    general_config=build_devnet_general_config(
-                        StarknetChainId[self.config.chain_id]
-                    )
+                    general_config=build_devnet_general_config(self.config.chain_id)
                 )
 
         return self.starknet

--- a/test/account.py
+++ b/test/account.py
@@ -109,8 +109,8 @@ def _get_execute_args(
     private_key: int,
     nonce: int,
     version: int,
-    chain_id=StarknetChainId.TESTNET,
     max_fee=None,
+    chain_id=StarknetChainId.TESTNET,
 ):
     """Returns signature and execute calldata"""
 
@@ -157,9 +157,9 @@ def get_estimated_fee(
     calls: List[AccountCall],
     account_address: str,
     private_key: str,
-    chain_id=StarknetChainId.TESTNET,
     nonce=None,
     feeder_gateway_url=APP_URL,
+    chain_id=StarknetChainId.TESTNET,
 ):
     """Get estimated fee through account."""
 
@@ -191,10 +191,10 @@ def invoke(
     calls: List[AccountCall],
     account_address: str,
     private_key: int,
-    chain_id=StarknetChainId.TESTNET,
     nonce=None,
     max_fee=None,
     gateway_url=APP_URL,
+    chain_id=StarknetChainId.TESTNET,
 ):
     """Invoke __execute__ with correct calldata and signature."""
 

--- a/test/account.py
+++ b/test/account.py
@@ -109,6 +109,7 @@ def _get_execute_args(
     private_key: int,
     nonce: int,
     version: int,
+    chain_id=StarknetChainId.TESTNET,
     max_fee=None,
 ):
     """Returns signature and execute calldata"""
@@ -124,6 +125,7 @@ def _get_execute_args(
         nonce=nonce,
         version=version,
         max_fee=max_fee,
+        chain_id=chain_id,
     )
     signature = _get_signature(message_hash, private_key)
 
@@ -136,6 +138,7 @@ def _get_transaction_hash(
     nonce: int,
     version: int,
     max_fee: int,
+    chain_id=StarknetChainId.TESTNET,
 ) -> str:
     """Get transaction hash for execute transaction."""
     return calculate_transaction_hash_common(
@@ -145,7 +148,7 @@ def _get_transaction_hash(
         entry_point_selector=0,
         calldata=calldata,
         max_fee=max_fee,
-        chain_id=StarknetChainId.TESTNET.value,
+        chain_id=chain_id.value,
         additional_data=[nonce],
     )
 
@@ -154,6 +157,7 @@ def get_estimated_fee(
     calls: List[AccountCall],
     account_address: str,
     private_key: str,
+    chain_id=StarknetChainId.TESTNET,
     nonce=None,
     feeder_gateway_url=APP_URL,
 ):
@@ -169,6 +173,7 @@ def get_estimated_fee(
         nonce=nonce,
         max_fee=0,
         version=QUERY_VERSION,
+        chain_id=chain_id,
     )
 
     return estimate_fee(
@@ -186,6 +191,7 @@ def invoke(
     calls: List[AccountCall],
     account_address: str,
     private_key: int,
+    chain_id=StarknetChainId.TESTNET,
     nonce=None,
     max_fee=None,
     gateway_url=APP_URL,
@@ -202,6 +208,7 @@ def invoke(
             private_key=private_key,
             nonce=nonce,
             feeder_gateway_url=gateway_url,
+            chain_id=chain_id,
         )
 
     signature, execute_calldata = _get_execute_args(
@@ -211,6 +218,7 @@ def invoke(
         nonce=nonce,
         version=SUPPORTED_TX_VERSION,
         max_fee=max_fee,
+        chain_id=chain_id,
     )
 
     adapted_inputs = _adapt_inputs(execute_calldata)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -26,6 +26,14 @@ def fixture_expected_block_hash(request):
     return request.param
 
 
+@pytest.fixture(name="chain_id")
+def fixture_chain_id(request):
+    """
+    Fixture to return values of chain id
+    """
+    return request.param
+
+
 @pytest.fixture(name="run_devnet_in_background")
 def fixture_run_devnet_in_background(request) -> None:
     """

--- a/test/test_chain_id_cli_params.py
+++ b/test/test_chain_id_cli_params.py
@@ -20,6 +20,7 @@ def test_chain_id_valid(chain_id):
         "--chain-id",
         chain_id,
     )
+    terminate_and_wait(proc)
     assert proc.returncode is None
 
 
@@ -35,7 +36,6 @@ def test_chain_id_invalid(chain_id):
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
     )
-    terminate_and_wait(proc)
     assert (
         f"Error: The value of --chain_id must be in {[member.name for member in StarknetChainId]}, got:"
         in read_stream(proc.stderr)

--- a/test/test_chain_id_cli_params.py
+++ b/test/test_chain_id_cli_params.py
@@ -3,8 +3,8 @@
 import subprocess
 import pytest
 
-from .util import DevnetBackgroundProc, read_stream
 from starkware.starknet.definitions.general_config import StarknetChainId
+from .util import DevnetBackgroundProc, read_stream
 
 ACTIVE_DEVNET = DevnetBackgroundProc()
 
@@ -18,7 +18,7 @@ def test_chain_id_valid(chain_id):
         "--chain-id",
         chain_id,
     )
-    assert proc.returncode == None
+    assert proc.returncode is None
 
 def test_chain_id_invalid():
     """Test if the invalid chain id fails"""
@@ -29,7 +29,7 @@ def test_chain_id_invalid():
         stdout=subprocess.PIPE,
     )
     assert (
-        f"The value of --chain_id must be in {[member.name for member in StarknetChainId]}, got: " 
+        f"The value of --chain_id must be in {[member.name for member in StarknetChainId]}, got:"
         in read_stream(proc.stderr)
     )
     assert proc.returncode == 1

--- a/test/test_chain_id_cli_params.py
+++ b/test/test_chain_id_cli_params.py
@@ -37,7 +37,7 @@ def test_chain_id_invalid(chain_id):
     )
     terminate_and_wait(proc)
     assert (
-        f"The value of --chain_id must be in {[member.name for member in StarknetChainId]}, got:"
+        f"Error: The value of --chain_id must be in {[member.name for member in StarknetChainId]}, got:"
         in read_stream(proc.stderr)
     )
     assert proc.returncode == 1

--- a/test/test_chain_id_cli_params.py
+++ b/test/test_chain_id_cli_params.py
@@ -1,9 +1,10 @@
 """Testing chain id CLI params"""
 
 import subprocess
-import pytest
 
+import pytest
 from starkware.starknet.definitions.general_config import StarknetChainId
+
 from .util import DevnetBackgroundProc, read_stream
 
 ACTIVE_DEVNET = DevnetBackgroundProc()

--- a/test/test_chain_id_cli_params.py
+++ b/test/test_chain_id_cli_params.py
@@ -1,0 +1,35 @@
+"""Testing chain id CLI params"""
+
+import subprocess
+import pytest
+
+from .util import DevnetBackgroundProc, read_stream
+from starkware.starknet.definitions.general_config import StarknetChainId
+
+ACTIVE_DEVNET = DevnetBackgroundProc()
+
+@pytest.mark.parametrize(
+    "chain_id",
+    [member.name for member in StarknetChainId],
+)
+def test_chain_id_valid(chain_id):
+    """Test if chain id works"""
+    proc = ACTIVE_DEVNET.start(
+        "--chain-id",
+        chain_id,
+    )
+    assert proc.returncode == None
+
+def test_chain_id_invalid():
+    """Test if the invalid chain id fails"""
+    proc = ACTIVE_DEVNET.start(
+        "--chain-id",
+        "",
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+    )
+    assert (
+        f"The value of --chain_id must be in {[member.name for member in StarknetChainId]}, got: " 
+        in read_stream(proc.stderr)
+    )
+    assert proc.returncode == 1

--- a/test/test_chain_id_cli_params.py
+++ b/test/test_chain_id_cli_params.py
@@ -5,6 +5,8 @@ import subprocess
 import pytest
 from starkware.starknet.definitions.general_config import StarknetChainId
 
+from starknet_devnet.devnet_config import CHAIN_IDS
+
 from .account import invoke
 from .shared import (
     ABI_PATH,
@@ -54,7 +56,7 @@ def test_chain_id_invalid(chain_id):
         stdout=subprocess.PIPE,
     )
     assert (
-        f"Error: The value of --chain_id must be in {[member.name for member in StarknetChainId]}, got:"
+        f"Error: The value of --chain_id must be in {{{CHAIN_IDS}}}, got:"
         in read_stream(proc.stderr)
     )
     assert proc.returncode == 1

--- a/test/test_chain_id_cli_params.py
+++ b/test/test_chain_id_cli_params.py
@@ -9,6 +9,7 @@ from .util import DevnetBackgroundProc, read_stream
 
 ACTIVE_DEVNET = DevnetBackgroundProc()
 
+
 @pytest.mark.parametrize(
     "chain_id",
     [member.name for member in StarknetChainId],
@@ -20,6 +21,7 @@ def test_chain_id_valid(chain_id):
         chain_id,
     )
     assert proc.returncode is None
+
 
 def test_chain_id_invalid():
     """Test if the invalid chain id fails"""

--- a/test/test_chain_id_cli_params.py
+++ b/test/test_chain_id_cli_params.py
@@ -5,7 +5,7 @@ import subprocess
 import pytest
 from starkware.starknet.definitions.general_config import StarknetChainId
 
-from .util import DevnetBackgroundProc, read_stream
+from .util import DevnetBackgroundProc, read_stream, terminate_and_wait
 
 ACTIVE_DEVNET = DevnetBackgroundProc()
 
@@ -23,14 +23,19 @@ def test_chain_id_valid(chain_id):
     assert proc.returncode is None
 
 
-def test_chain_id_invalid():
+@pytest.mark.parametrize(
+    "chain_id",
+    ["", "mainnet2"],
+)
+def test_chain_id_invalid(chain_id):
     """Test if the invalid chain id fails"""
     proc = ACTIVE_DEVNET.start(
         "--chain-id",
-        "",
+        chain_id,
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
     )
+    terminate_and_wait(proc)
     assert (
         f"The value of --chain_id must be in {[member.name for member in StarknetChainId]}, got:"
         in read_stream(proc.stderr)

--- a/test/test_chain_id_cli_params.py
+++ b/test/test_chain_id_cli_params.py
@@ -5,7 +5,24 @@ import subprocess
 import pytest
 from starkware.starknet.definitions.general_config import StarknetChainId
 
-from .util import DevnetBackgroundProc, read_stream, terminate_and_wait
+from .account import invoke
+from .shared import (
+    ABI_PATH,
+    CONTRACT_PATH,
+    PREDEPLOY_ACCOUNT_CLI_ARGS,
+    PREDEPLOYED_ACCOUNT_ADDRESS,
+    PREDEPLOYED_ACCOUNT_PRIVATE_KEY,
+)
+from .util import (
+    DevnetBackgroundProc,
+    assert_equal,
+    assert_transaction,
+    assert_tx_status,
+    call,
+    deploy,
+    read_stream,
+    terminate_and_wait,
+)
 
 ACTIVE_DEVNET = DevnetBackgroundProc()
 
@@ -41,3 +58,40 @@ def test_chain_id_invalid(chain_id):
         in read_stream(proc.stderr)
     )
     assert proc.returncode == 1
+
+
+@pytest.mark.usefixtures("run_devnet_in_background")
+@pytest.mark.parametrize(
+    "run_devnet_in_background, chain_id",
+    [
+        (
+            [*PREDEPLOY_ACCOUNT_CLI_ARGS, "--chain-id", StarknetChainId.TESTNET.name],
+            StarknetChainId.TESTNET,
+        ),
+        (
+            [*PREDEPLOY_ACCOUNT_CLI_ARGS, "--chain-id", StarknetChainId.MAINNET.name],
+            StarknetChainId.MAINNET,
+        ),
+    ],
+    indirect=True,
+)
+def test_deploy_and_invoke(chain_id):
+    """Test deploy and invoke with MAINNET and TESTNET chain_id"""
+    deploy_info = deploy(CONTRACT_PATH, inputs=["0"])
+
+    assert_tx_status(deploy_info["tx_hash"], "ACCEPTED_ON_L2")
+    assert_transaction(deploy_info["tx_hash"], "ACCEPTED_ON_L2")
+
+    # increase and assert balance
+    invoke_tx_hash = invoke(
+        calls=[(deploy_info["address"], "increase_balance", [10, 20])],
+        account_address=PREDEPLOYED_ACCOUNT_ADDRESS,
+        private_key=PREDEPLOYED_ACCOUNT_PRIVATE_KEY,
+        chain_id=chain_id,
+    )
+    assert_transaction(invoke_tx_hash, "ACCEPTED_ON_L2")
+
+    value = call(
+        function="get_balance", address=deploy_info["address"], abi_path=ABI_PATH
+    )
+    assert_equal(value, "30", "Invoke+call failed!")

--- a/test/test_chain_id_cli_params.py
+++ b/test/test_chain_id_cli_params.py
@@ -21,7 +21,7 @@ def test_chain_id_valid(chain_id):
         chain_id,
     )
     terminate_and_wait(proc)
-    assert proc.returncode is None
+    assert proc.returncode == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Usage related changes

- User can specify `--chain_id` argument as "MAINNET" or "TESTNET"

## Development related changes

- `DEFAULT_GENERAL_CONFIG` is now assignet to `build_devnet_general_config()` function in tests.

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
