### PR TITLE
Mempool blocks generation

### DIFF
--- a/page/docs/guide/blocks.md
+++ b/page/docs/guide/blocks.md
@@ -36,7 +36,7 @@ Response:
 
 ### Create a block on demand
 
-To create a block on demand with many transactions we can use `--blocks-on-demand` mode and a `POST` request to `/create_block_on_demand` which will include all mempool transactions in new block. The genesis block will be added normally.
+To create a block on demand with many transactions we can use `--blocks-on-demand` mode and a `POST` request to `/create_block_on_demand` which will include all mempool transactions in a new block. In case of no transactions in mempool new empty block will be generated. The genesis block will be generated normally.
 
 ```
 POST /create_block_on_demand

--- a/page/docs/guide/blocks.md
+++ b/page/docs/guide/blocks.md
@@ -36,7 +36,7 @@ Response:
 
 ### Create a block on demand
 
-To create a block on demand with many transactions we can use `--blocks-on-demand` mode and a `POST` request to `/create_block_on_demand` which will include all mempool transactions in new block:
+To create a block on demand with many transactions we can use `--blocks-on-demand` mode and a `POST` request to `/create_block_on_demand` which will include all mempool transactions in new block. The genesis block will be added normally.
 
 ```
 POST /create_block_on_demand

--- a/page/docs/guide/blocks.md
+++ b/page/docs/guide/blocks.md
@@ -36,7 +36,7 @@ Response:
 
 ### Create a block on demand
 
-To create a block on demand with many transactions we can use `--blocks-on-demand` mode and a `POST` request to `/create_block_on_demand` which will include all pending transactions in new block:
+To create a block on demand with many transactions we can use `--blocks-on-demand` mode and a `POST` request to `/create_block_on_demand` which will include all mempool transactions in new block:
 
 ```
 POST /create_block_on_demand

--- a/page/docs/guide/blocks.md
+++ b/page/docs/guide/blocks.md
@@ -33,3 +33,17 @@ Response:
     "status": "ACCEPTED_ON_L2"
 }
 ```
+
+### Create a block on demand
+
+To create a block on demand with many transactions we can use `--blocks-on-demand` mode and a `POST` request to `/create_block_on_demand` which will include all pending transactions in new block:
+
+```
+POST /create_block_on_demand
+```
+
+Response:
+
+```
+{'block_hash': '0x115e1b390cafa7942b6ab141ab85040defe7dee9bef3bc31d8b5b3d01cc9c67'}
+```

--- a/page/docs/guide/run.md
+++ b/page/docs/guide/run.md
@@ -10,7 +10,7 @@ Installing the package adds the `starknet-devnet` command.
 usage: starknet-devnet [-h] [-v] [--host HOST] [--port PORT] [--load-path LOAD_PATH] [--dump-path DUMP_PATH] [--dump-on DUMP_ON] [--lite-mode] [--accounts ACCOUNTS]
                        [--initial-balance INITIAL_BALANCE] [--seed SEED] [--hide-predeployed-accounts] [--start-time START_TIME] [--gas-price GAS_PRICE] [--timeout TIMEOUT]
                        [--account-class ACCOUNT_CLASS] [--fork-network FORK_NETWORK] [--fork-block FORK_BLOCK]
-                       [--chain-id CHAIN_ID]
+                       [--chain-id CHAIN_ID] [--blocks-on-demand]
 
 Run a local instance of StarkNet Devnet
 
@@ -25,6 +25,7 @@ optional arguments:
                         Specify the path to dump to
   --dump-on DUMP_ON     Specify when to dump; can dump on: exit, transaction
   --lite-mode           Introduces speed-up by skipping block hash calculation - applies sequential numbering instead (0x0, 0x1, 0x2, ...).
+  --blocks-on-demand    Introduces block generation on demand via /create_block_on_demand endpoint
   --accounts ACCOUNTS   Specify the number of accounts to be predeployed; defaults to 10
   --initial-balance INITIAL_BALANCE, -e INITIAL_BALANCE
                         Specify the initial balance of accounts to be predeployed; defaults to 1e+21

--- a/starknet_devnet/blocks.py
+++ b/starknet_devnet/blocks.py
@@ -124,7 +124,6 @@ class DevnetBlocks:
         block_number = self.get_number_of_blocks()
         timestamp = state.state.block_info.block_timestamp
         signatures = []
-        tx_hashes = []
         internal_transactions = []
 
         if block_number == 0:
@@ -140,7 +139,6 @@ class DevnetBlocks:
             transaction_receipts = tuple(tx.get_execution() for tx in transactions)
             internal_transactions = [tx.internal_tx for tx in transactions]
             signatures = [tx.get_signature() for tx in transactions]
-            tx_hashes = [tx.hash_value for tx in internal_transactions]
 
         if self.lite or is_empty_block:
             block_hash = block_number
@@ -151,7 +149,7 @@ class DevnetBlocks:
                 block_number=block_number,
                 global_state_root=state_root,
                 block_timestamp=timestamp,
-                tx_hashes=tx_hashes,
+                tx_hashes=[tx.hash_value for tx in internal_transactions],
                 tx_signatures=signatures,
                 event_hashes=[],
                 sequencer_address=state.general_config.sequencer_address,

--- a/starknet_devnet/blocks.py
+++ b/starknet_devnet/blocks.py
@@ -2,7 +2,7 @@
 Class for generating and handling blocks
 """
 
-from typing import Dict
+from typing import Dict, List
 
 from starkware.starknet.core.os.block_hash.block_hash import calculate_block_hash
 from starkware.starknet.definitions.error_codes import StarknetErrorCode
@@ -110,7 +110,7 @@ class DevnetBlocks:
 
     async def generate(
         self,
-        transaction: DevnetTransaction,
+        transactions: List[DevnetTransaction],
         state: StarknetState,
         state_update=None,
         is_empty_block=False,
@@ -123,31 +123,36 @@ class DevnetBlocks:
         state_root = DUMMY_STATE_ROOT
         block_number = self.get_number_of_blocks()
         timestamp = state.state.block_info.block_timestamp
+        signatures = []
+        tx_hashes = []
+        internal_transactions = []
+
         if block_number == 0:
             parent_block_hash = 0
         else:
             last_block = await self.get_last_block()
             parent_block_hash = last_block.block_hash
-
+        
         if is_empty_block:
             transaction_receipts = ()
             transactions = []
         else:
-            transaction_receipts = (transaction.get_execution(),)
-            transactions = [transaction.internal_tx]
+            transaction_receipts = (transactions[0].get_execution(),) #TODO: fix this later
+            internal_transactions = [tx.internal_tx for tx in transactions]
+            signatures = [tx.get_signature() for tx in transactions]
+            tx_hashes = [tx.hash_value for tx in internal_transactions]
 
         if self.lite or is_empty_block:
             block_hash = block_number
         else:
-            signature = transaction.get_signature()
             block_hash = await calculate_block_hash(
                 general_config=state.general_config,
                 parent_hash=parent_block_hash,
                 block_number=block_number,
                 global_state_root=state_root,
                 block_timestamp=timestamp,
-                tx_hashes=[transaction.internal_tx.hash_value],
-                tx_signatures=[signature],
+                tx_hashes=tx_hashes,
+                tx_signatures=signatures,
                 event_hashes=[],
                 sequencer_address=state.general_config.sequencer_address,
             )
@@ -156,7 +161,7 @@ class DevnetBlocks:
             block_hash=block_hash,
             block_number=block_number,
             state_root=state_root,
-            transactions=transactions,
+            transactions=internal_transactions,
             timestamp=timestamp,
             transaction_receipts=transaction_receipts,
             status=BlockStatus.ACCEPTED_ON_L2,

--- a/starknet_devnet/blocks.py
+++ b/starknet_devnet/blocks.py
@@ -137,9 +137,7 @@ class DevnetBlocks:
             transaction_receipts = ()
             transactions = []
         else:
-            transaction_receipts = (
-                transactions[0].get_execution(),
-            )  # TODO: fix this later
+            transaction_receipts = tuple(tx.get_execution() for tx in transactions)
             internal_transactions = [tx.internal_tx for tx in transactions]
             signatures = [tx.get_signature() for tx in transactions]
             tx_hashes = [tx.hash_value for tx in internal_transactions]

--- a/starknet_devnet/blocks.py
+++ b/starknet_devnet/blocks.py
@@ -132,12 +132,14 @@ class DevnetBlocks:
         else:
             last_block = await self.get_last_block()
             parent_block_hash = last_block.block_hash
-        
+
         if is_empty_block:
             transaction_receipts = ()
             transactions = []
         else:
-            transaction_receipts = (transactions[0].get_execution(),) #TODO: fix this later
+            transaction_receipts = (
+                transactions[0].get_execution(),
+            )  # TODO: fix this later
             internal_transactions = [tx.internal_tx for tx in transactions]
             signatures = [tx.get_signature() for tx in transactions]
             tx_hashes = [tx.hash_value for tx in internal_transactions]

--- a/starknet_devnet/blocks.py
+++ b/starknet_devnet/blocks.py
@@ -123,8 +123,9 @@ class DevnetBlocks:
         state_root = DUMMY_STATE_ROOT
         block_number = self.get_number_of_blocks()
         timestamp = state.state.block_info.block_timestamp
-        signatures = []
-        internal_transactions = []
+        signatures = [tx.get_signature() for tx in transactions or []]
+        internal_transactions = [tx.internal_tx for tx in transactions or []]
+        transaction_receipts = tuple(tx.get_execution() for tx in transactions or ())
 
         if block_number == 0:
             parent_block_hash = 0
@@ -132,16 +133,9 @@ class DevnetBlocks:
             last_block = await self.get_last_block()
             parent_block_hash = last_block.block_hash
 
-        if is_empty_block:
-            transaction_receipts = ()
-            transactions = []
-        else:
-            transaction_receipts = tuple(tx.get_execution() for tx in transactions)
-            internal_transactions = [tx.internal_tx for tx in transactions]
-            signatures = [tx.get_signature() for tx in transactions]
-
         if self.lite or is_empty_block:
             block_hash = block_number
+            transactions = []
         else:
             block_hash = await calculate_block_hash(
                 general_config=state.general_config,

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -194,6 +194,13 @@ async def create_block():
     block = await state.starknet_wrapper.create_empty_block()
     return Response(block.dumps(), status=200, mimetype="application/json")
 
+@base.route("/create_block_on_demand", methods=["POST"])
+async def create_block_on_demand():
+    """Create block on demand"""
+    block = await state.starknet_wrapper.store_pending_transactions()
+    print(block.transactions)
+
+    return Response(block, status=200, mimetype="application/json")
 
 @base.route("/fork_status", methods=["GET"])
 async def fork_status():

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -200,7 +200,7 @@ async def create_block_on_demand():
     block = await state.starknet_wrapper.store_pending_transactions()
     print(block.transactions)
 
-    return Response(block, status=200, mimetype="application/json")
+    return jsonify({"block_hash": block.block_hash})
 
 @base.route("/fork_status", methods=["GET"])
 async def fork_status():

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -194,13 +194,14 @@ async def create_block():
     block = await state.starknet_wrapper.create_empty_block()
     return Response(block.dumps(), status=200, mimetype="application/json")
 
+
 @base.route("/create_block_on_demand", methods=["POST"])
 async def create_block_on_demand():
     """Create block on demand"""
     block = await state.starknet_wrapper.store_pending_transactions()
-    print(block.transactions)
 
     return jsonify({"block_hash": hex(block.block_hash)})
+
 
 @base.route("/fork_status", methods=["GET"])
 async def fork_status():

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -200,7 +200,7 @@ async def create_block_on_demand():
     block = await state.starknet_wrapper.store_pending_transactions()
     print(block.transactions)
 
-    return jsonify({"block_hash": block.block_hash})
+    return jsonify({"block_hash": hex(block.block_hash)})
 
 @base.route("/fork_status", methods=["GET"])
 async def fork_status():

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -198,7 +198,7 @@ async def create_block():
 @base.route("/create_block_on_demand", methods=["POST"])
 async def create_block_on_demand():
     """Create block on demand"""
-    block = await state.starknet_wrapper.store_pending_transactions()
+    block = await state.starknet_wrapper.store_mempool_transactions()
 
     return jsonify({"block_hash": hex(block.block_hash)})
 

--- a/starknet_devnet/blueprints/feeder_gateway.py
+++ b/starknet_devnet/blueprints/feeder_gateway.py
@@ -12,6 +12,7 @@ from starkware.starknet.services.api.feeder_gateway.response_objects import (
     BlockTransactionTraces,
     StarknetBlock,
     TransactionSimulationInfo,
+    TransactionStatus,
 )
 from starkware.starknet.services.api.gateway.transaction import (
     AccountTransaction,
@@ -210,6 +211,18 @@ async def get_transaction_status():
     tx_status = await state.starknet_wrapper.transactions.get_transaction_status(
         transaction_hash
     )
+
+    # In case of blocks-on-demand feature tx_status should be received
+    if (
+        state.starknet_wrapper.config.blocks_on_demand
+        and tx_status["tx_status"] == TransactionStatus.NOT_RECEIVED.name
+        and any(
+            hex(transaction.transaction_hash) == transaction_hash
+            for transaction in state.starknet_wrapper.mempool
+        )
+    ):
+        tx_status["tx_status"] = TransactionStatus.RECEIVED.name
+
     return jsonify(tx_status)
 
 

--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -229,6 +229,11 @@ def parse_args(raw_args: List[str]):
         " - applies sequential numbering instead (0x0, 0x1, 0x2, ...).",
     )
     parser.add_argument(
+        "--blocks-on-demand",
+        action="store_true",
+        help="Block generation on demand via an endpoint.",
+    )
+    parser.add_argument(
         "--accounts",
         action=NonNegativeAction,
         help=f"Specify the number of accounts to be predeployed; defaults to {DEFAULT_ACCOUNTS}",
@@ -327,6 +332,7 @@ class DevnetConfig:
         self.start_time = self.args.start_time
         self.gas_price = self.args.gas_price
         self.lite_mode = self.args.lite_mode
+        self.blocks_on_demand = self.args.blocks_on_demand
         self.account_class = self.args.account_class
         self.hide_predeployed_accounts = self.args.hide_predeployed_accounts
         self.fork_network = self.args.fork_network

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -253,7 +253,8 @@ class StarknetWrapper:
         """
         Stores the provided transactions in new block.
         """
-        # TODO: update this according to _store_transaction() method?
+        # Fabijan I'm not sure about this... Let's discuss it during PR.
+        # Update this according to _store_transaction() method?
         return await self.blocks.generate(
             transactions,
             self.get_state(),

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -35,6 +35,7 @@ from starkware.starknet.services.api.feeder_gateway.response_objects import (
     BlockStateUpdate,
     DeployedContract,
     StateDiff,
+    StarknetBlock,
     StorageEntry,
     TransactionStatus,
     TransactionTrace,
@@ -244,6 +245,24 @@ class StarknetWrapper:
             transaction.set_block(block=block)
 
         self.transactions.store(tx_hash, transaction)
+
+    async def _store_transactions(
+        self,
+        transactions: DevnetTransactions,
+        state_update: Dict,
+    ) -> StarknetBlock:
+        """
+        Stores the provided transactions in new block.
+        """
+        # TODO: update this according to _store_transaction() method
+        state = self.get_state()
+        block = await self.blocks.generate(
+            transactions,
+            state,
+            state_update=state_update,
+        )
+
+        return block
 
     async def declare(self, external_tx: Declare) -> Tuple[int, int]:
         """
@@ -603,6 +622,18 @@ class StarknetWrapper:
                 )
 
         return parsed_l1_l2_messages
+
+    async def store_pending_transactions(self) -> dict:
+        """Generate new block with pending transactions in --blocks-on-demand mode."""
+        state = self.get_state()
+
+        # Generate new block with pending transactions
+        block = await self._store_transactions(
+            transactions=self.pending_transactions,
+            state_update=state,
+        )
+
+        return block
 
     async def calculate_trace_and_fee(self, external_tx: InvokeFunction):
         """Calculates trace and fee by simulating tx on state copy."""

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -236,7 +236,7 @@ class StarknetWrapper:
             state = self.get_state()
 
             block = await self.blocks.generate(
-                transaction,
+                [transaction],
                 state,
                 state_update=state_update,
             )

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -106,7 +106,7 @@ class StarknetWrapper:
         self.fee_token = FeeToken(self)
         self.accounts = Accounts(self)
         self.__udc = UDC(self)
-        self.pending_transactions = []
+        self.mempool = []
 
         if config.start_time is not None:
             self.set_block_time(config.start_time)
@@ -376,7 +376,7 @@ class StarknetWrapper:
                 )
 
                 if self.starknet_wrapper.config.blocks_on_demand:
-                    self.starknet_wrapper.pending_transactions.append(transaction)
+                    self.starknet_wrapper.mempool.append(transaction)
                 else:
                     await self.starknet_wrapper._store_transaction(
                         transaction=transaction,
@@ -630,10 +630,10 @@ class StarknetWrapper:
 
         return parsed_l1_l2_messages
 
-    async def store_pending_transactions(self) -> StarknetBlock:
-        """Generate new block with pending transactions in --blocks-on-demand mode."""
+    async def store_mempool_transactions(self) -> StarknetBlock:
+        """Generate new block with mempool transactions in --blocks-on-demand mode."""
         return await self._store_transactions(
-            transactions=self.pending_transactions,
+            transactions=self.mempool,
         )
 
     async def calculate_trace_and_fee(self, external_tx: InvokeFunction):

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -266,7 +266,7 @@ class StarknetWrapper:
         )
 
         for transaction in transactions:
-            transaction.set_block(block=block)            
+            transaction.set_block(block=block)
             self.transactions.store(transaction.transaction_hash, transaction)
 
         return block

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -258,17 +258,18 @@ class StarknetWrapper:
         """
         for transaction in transactions:
             if transaction.status == TransactionStatus.REJECTED:
-                assert error_message, "error_message must be present if tx rejected"
                 transaction.set_failure_reason(error_message)
+        
+        for transaction in transactions:
+            transaction.set_block(block=block)
+            self.transactions.store(transaction.transaction_hash, transaction)
 
+        # Filter out rejected transactions
+        transactions = list(filter(lambda tx: tx.status != TransactionStatus.REJECTED, transactions))
         block = await self.blocks.generate(
             transactions,
             self.get_state(),
         )
-
-        for transaction in transactions:
-            transaction.set_block(block=block)
-            self.transactions.store(transaction.transaction_hash, transaction)
 
         return block
 
@@ -464,6 +465,12 @@ class StarknetWrapper:
         """Perform invoke according to specifications in `transaction`."""
         state = self.get_state()
 
+        # use mempool state to invoke and reject transaction second
+        # TODO: fix later
+        # if self.config.blocks_on_demand and self.__mempool_state is not None:
+        #     print("use mempool state to invoke and reject transaction second")
+        #     state = self.__mempool_state
+
         async with self.__get_transaction_handler() as tx_handler:
             tx_handler.internal_tx = InternalInvokeFunction.from_external(
                 external_tx, state.general_config
@@ -639,6 +646,7 @@ class StarknetWrapper:
         """Generate new block with mempool transactions in --blocks-on-demand mode."""
 
         # Update mempool state before block generation
+        # TODO: this approach is wrong because of rejected transactions
         self.__mempool_state = self.get_state().copy()
 
         # Store transactions and clear mempool

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -107,6 +107,7 @@ class StarknetWrapper:
         self.accounts = Accounts(self)
         self.__udc = UDC(self)
         self.mempool = []
+        self.mempool_state = None
 
         if config.start_time is not None:
             self.set_block_time(config.start_time)
@@ -131,6 +132,7 @@ class StarknetWrapper:
 
             await self.__preserve_current_state(starknet.state.state)
             await self.create_empty_block()
+            self.mempool_state = self.get_state().copy()
             self.__initialized = True
 
     async def create_empty_block(self):
@@ -479,7 +481,11 @@ class StarknetWrapper:
     async def call(self, transaction: CallFunction):
         """Perform call according to specifications in `transaction`."""
 
-        state_copy = self.get_state().copy()
+        if self.config.blocks_on_demand and self.mempool_state is not None:
+            state_copy = self.mempool_state
+        else:
+            state_copy = self.get_state().copy()
+
         call_info = await state_copy.execute_entry_point_raw(
             contract_address=transaction.contract_address,
             selector=transaction.entry_point_selector,
@@ -631,6 +637,10 @@ class StarknetWrapper:
 
     async def store_mempool_transactions(self) -> StarknetBlock:
         """Generate new block with mempool transactions in --blocks-on-demand mode."""
+
+        # Update mempool state before block generation
+        self.mempool_state = self.get_state().copy()
+
         return await self._store_transactions(
             transactions=self.mempool,
         )

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -34,8 +34,8 @@ from starkware.starknet.services.api.feeder_gateway.request_objects import (
 from starkware.starknet.services.api.feeder_gateway.response_objects import (
     BlockStateUpdate,
     DeployedContract,
-    StateDiff,
     StarknetBlock,
+    StateDiff,
     StorageEntry,
     TransactionStatus,
     TransactionTrace,

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -641,9 +641,13 @@ class StarknetWrapper:
         # Update mempool state before block generation
         self.__mempool_state = self.get_state().copy()
 
-        return await self._store_transactions(
+        # Store transactions and clear mempool
+        result = await self._store_transactions(
             transactions=self.mempool,
         )
+        self.mempool = []
+
+        return result
 
     async def calculate_trace_and_fee(self, external_tx: InvokeFunction):
         """Calculates trace and fee by simulating tx on state copy."""

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -107,7 +107,7 @@ class StarknetWrapper:
         self.accounts = Accounts(self)
         self.__udc = UDC(self)
         self.mempool = []
-        self.mempool_state = None
+        self.__mempool_state = None
 
         if config.start_time is not None:
             self.set_block_time(config.start_time)
@@ -132,7 +132,7 @@ class StarknetWrapper:
 
             await self.__preserve_current_state(starknet.state.state)
             await self.create_empty_block()
-            self.mempool_state = self.get_state().copy()
+            self.__mempool_state = self.get_state().copy()
             self.__initialized = True
 
     async def create_empty_block(self):
@@ -481,8 +481,8 @@ class StarknetWrapper:
     async def call(self, transaction: CallFunction):
         """Perform call according to specifications in `transaction`."""
 
-        if self.config.blocks_on_demand and self.mempool_state is not None:
-            state_copy = self.mempool_state
+        if self.config.blocks_on_demand and self.__mempool_state is not None:
+            state_copy = self.__mempool_state
         else:
             state_copy = self.get_state().copy()
 
@@ -639,7 +639,7 @@ class StarknetWrapper:
         """Generate new block with mempool transactions in --blocks-on-demand mode."""
 
         # Update mempool state before block generation
-        self.mempool_state = self.get_state().copy()
+        self.__mempool_state = self.get_state().copy()
 
         return await self._store_transactions(
             transactions=self.mempool,

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -248,21 +248,16 @@ class StarknetWrapper:
 
     async def _store_transactions(
         self,
-        transactions: DevnetTransactions,
-        state_update: Dict,
+        transactions: List[DevnetTransaction],
     ) -> StarknetBlock:
         """
         Stores the provided transactions in new block.
         """
-        # TODO: update this according to _store_transaction() method
-        state = self.get_state()
-        block = await self.blocks.generate(
+        # TODO: update this according to _store_transaction() method?
+        return await self.blocks.generate(
             transactions,
-            state,
-            state_update=state_update,
+            self.get_state(),
         )
-
-        return block
 
     async def declare(self, external_tx: Declare) -> Tuple[int, int]:
         """
@@ -623,17 +618,11 @@ class StarknetWrapper:
 
         return parsed_l1_l2_messages
 
-    async def store_pending_transactions(self) -> dict:
+    async def store_pending_transactions(self) -> StarknetBlock:
         """Generate new block with pending transactions in --blocks-on-demand mode."""
-        state = self.get_state()
-
-        # Generate new block with pending transactions
-        block = await self._store_transactions(
+        return await self._store_transactions(
             transactions=self.pending_transactions,
-            state_update=state,
         )
-
-        return block
 
     async def calculate_trace_and_fee(self, external_tx: InvokeFunction):
         """Calculates trace and fee by simulating tx on state copy."""

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -105,6 +105,7 @@ class StarknetWrapper:
         self.fee_token = FeeToken(self)
         self.accounts = Accounts(self)
         self.__udc = UDC(self)
+        self.pending_transactions = []
 
         if config.start_time is not None:
             self.set_block_time(config.start_time)
@@ -348,12 +349,15 @@ class StarknetWrapper:
                     transaction_hash=tx_hash,
                 )
 
-                await self.starknet_wrapper._store_transaction(
-                    transaction=transaction,
-                    state_update=state_update,
-                    error_message=error_message,
-                    tx_hash=tx_hash,
-                )
+                if self.starknet_wrapper.config.blocks_on_demand:
+                    self.starknet_wrapper.pending_transactions.append(transaction)
+                else:
+                    await self.starknet_wrapper._store_transaction(
+                        transaction=transaction,
+                        state_update=state_update,
+                        error_message=error_message,
+                        tx_hash=tx_hash,
+                    )
 
                 return True
 

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -249,16 +249,27 @@ class StarknetWrapper:
     async def _store_transactions(
         self,
         transactions: List[DevnetTransaction],
+        error_message: str = None,
     ) -> StarknetBlock:
         """
         Stores the provided transactions in new block.
         """
         # Fabijan I'm not sure about this... Let's discuss it during PR.
-        # Update this according to _store_transaction() method?
-        return await self.blocks.generate(
+        for transaction in transactions:
+            if transaction.status == TransactionStatus.REJECTED:
+                assert error_message, "error_message must be present if tx rejected"
+                transaction.set_failure_reason(error_message)
+
+        block = await self.blocks.generate(
             transactions,
             self.get_state(),
         )
+
+        for transaction in transactions:
+            transaction.set_block(block=block)            
+            self.transactions.store(transaction.transaction_hash, transaction)
+
+        return block
 
     async def declare(self, external_tx: Declare) -> Tuple[int, int]:
         """

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -254,7 +254,6 @@ class StarknetWrapper:
         """
         Stores the provided transactions in new block.
         """
-        # Fabijan I'm not sure about this... Let's discuss it during PR.
         for transaction in transactions:
             if transaction.status == TransactionStatus.REJECTED:
                 assert error_message, "error_message must be present if tx rejected"

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -18,15 +18,15 @@ from .util import (
 @devnet_in_background(*[*PREDEPLOY_ACCOUNT_CLI_ARGS,"--blocks-on-demand",])
 def test_blocks_on_demand():
     """Test deploy in blocks on demand mode"""
-    block = gateway_call("get_block", blockNumber="latest")
-    block_number_before_deploy = block["block_number"]
+    latest_block = gateway_call("get_block", blockNumber="latest")
+    block_number_before_deploy = latest_block["block_number"]
     deploy(contract=CONTRACT_PATH)
-    block = gateway_call("get_block", blockNumber="latest")
-    block_number_after_deploy = block["block_number"]
+    latest_block = gateway_call("get_block", blockNumber="latest")
+    block_number_after_deploy = latest_block["block_number"]
 
-    res = requests.post(f"{APP_URL}/create_block_on_demand")
-    block = gateway_call("get_block", blockNumber="latest")
-    block_number_after_block_on_demand_call = block["block_number"]
+    requests.post(f"{APP_URL}/create_block_on_demand")
+    latest_block = gateway_call("get_block", blockNumber="latest")
+    block_number_after_block_on_demand_call = latest_block["block_number"]
 
     assert block_number_before_deploy == 0
     assert block_number_after_deploy == 0

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -18,12 +18,7 @@ from .shared import (
 from .util import ReturnCodeAssertionError, call, deploy, devnet_in_background
 
 
-@devnet_in_background(
-    *[
-        *PREDEPLOY_ACCOUNT_CLI_ARGS,
-        "--blocks-on-demand",
-    ]
-)
+@devnet_in_background(*PREDEPLOY_ACCOUNT_CLI_ARGS, "--blocks-on-demand")
 def test_blocks_on_demand_invoke():
     """Test deploy in blocks on demand mode"""
     latest_block = gateway_call("get_block", blockNumber="latest")
@@ -66,12 +61,7 @@ def test_blocks_on_demand_invoke():
     assert len(latest_block["transactions"]) == 2
 
 
-@devnet_in_background(
-    *[
-        *PREDEPLOY_ACCOUNT_CLI_ARGS,
-        "--blocks-on-demand",
-    ]
-)
+@devnet_in_background(*PREDEPLOY_ACCOUNT_CLI_ARGS, "--blocks-on-demand")
 def test_blocks_on_demand_invoke_call():
     """Test deploy in blocks on demand mode for invoke and contract call"""
     # Deploy and invoke

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -66,6 +66,7 @@ def test_blocks_on_demand_invoke_call():
     """
     Test deploy in blocks on demand mode for invoke and contract call.
     Balance after invoke should be 0 even when we increased it.
+    Only after calling create_block_on_demand balance should be increased in this mode.
     """
     # Deploy and invoke
     deploy_info = deploy(CONTRACT_PATH, inputs=["0"])

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -1,0 +1,33 @@
+"""
+Test blocks on demand mode.
+"""
+
+import requests
+from test.rpc.rpc_utils import gateway_call
+
+from .settings import APP_URL
+from .shared import (
+    CONTRACT_PATH,
+    PREDEPLOY_ACCOUNT_CLI_ARGS,
+)
+from .util import (
+    deploy,
+    devnet_in_background,
+)
+
+@devnet_in_background(*[*PREDEPLOY_ACCOUNT_CLI_ARGS,"--blocks-on-demand",])
+def test_blocks_on_demand():
+    """Test deploy in blocks on demand mode"""
+    block = gateway_call("get_block", blockNumber="latest")
+    block_number_before_deploy = block["block_number"]
+    deploy(contract=CONTRACT_PATH)
+    block = gateway_call("get_block", blockNumber="latest")
+    block_number_after_deploy = block["block_number"]
+
+    res = requests.post(f"{APP_URL}/create_block_on_demand")
+    block = gateway_call("get_block", blockNumber="latest")
+    block_number_after_block_on_demand_call = block["block_number"]
+
+    assert block_number_before_deploy == 0
+    assert block_number_after_deploy == 0
+    assert block_number_after_block_on_demand_call == 1

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -63,7 +63,10 @@ def test_blocks_on_demand_invoke():
 
 @devnet_in_background(*PREDEPLOY_ACCOUNT_CLI_ARGS, "--blocks-on-demand")
 def test_blocks_on_demand_invoke_call():
-    """Test deploy in blocks on demand mode for invoke and contract call"""
+    """
+    Test deploy in blocks on demand mode for invoke and contract call.
+    Balance after invoke should be 0 even when we increased it.
+    """
     # Deploy and invoke
     deploy_info = deploy(CONTRACT_PATH, inputs=["0"])
     requests.post(f"{APP_URL}/create_block_on_demand")

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -20,7 +20,7 @@ from .util import ReturnCodeAssertionError, call, deploy, devnet_in_background
 
 @devnet_in_background(*PREDEPLOY_ACCOUNT_CLI_ARGS, "--blocks-on-demand")
 def test_blocks_on_demand_invoke():
-    """Test deploy in blocks on demand mode"""
+    """Test deploy in blocks-on-demand mode"""
     latest_block = gateway_call("get_block", blockNumber="latest")
     genesis_block_number = latest_block["block_number"]
     assert genesis_block_number == 0
@@ -64,7 +64,7 @@ def test_blocks_on_demand_invoke():
 @devnet_in_background(*PREDEPLOY_ACCOUNT_CLI_ARGS, "--blocks-on-demand")
 def test_blocks_on_demand_invoke_call():
     """
-    Test deploy in blocks on demand mode for invoke and contract call.
+    Test deploy in blocks-on-demand mode for invoke and contract call.
     Balance after invoke should be 0 even when we increased it.
     Only after calling create_block_on_demand balance should be increased in this mode.
     """

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -45,16 +45,19 @@ def test_blocks_on_demand_invoke():
     except ReturnCodeAssertionError as error:
         assert "StarknetErrorCode.UNINITIALIZED_CONTRACT" in str(error)
 
-    invoke(
+    invoke_hash = invoke(
         calls=[(deploy_info["address"], "increase_balance", [10, 20])],
         account_address=PREDEPLOYED_ACCOUNT_ADDRESS,
         private_key=PREDEPLOYED_ACCOUNT_PRIVATE_KEY,
     )
+    assert_tx_status(invoke_hash, "RECEIVED")
+
     latest_block = gateway_call("get_block", blockNumber="latest")
     block_number_after_deploy_and_invoke = latest_block["block_number"]
     assert block_number_after_deploy_and_invoke == 0
 
     requests.post(f"{APP_URL}/create_block_on_demand")
+    assert_tx_status(invoke_hash, "ACCEPTED_ON_L2")
 
     balance_after_create_block_on_demand = call(
         function="get_balance",

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -15,7 +15,7 @@ from .shared import (
     PREDEPLOYED_ACCOUNT_ADDRESS,
     PREDEPLOYED_ACCOUNT_PRIVATE_KEY,
 )
-from .util import call, deploy, devnet_in_background
+from .util import ReturnCodeAssertionError, call, deploy, devnet_in_background
 
 
 @devnet_in_background(
@@ -30,24 +30,41 @@ def test_blocks_on_demand_invoke():
     genesis_block_number = latest_block["block_number"]
     assert genesis_block_number == 0
 
-    # Deploy and invoke
     deploy_info = deploy(CONTRACT_PATH, inputs=["0"])
+    should_fail_on_contract_call = False
+    try:
+        call(
+            function="get_balance",
+            address=deploy_info["address"],
+            abi_path=ABI_PATH,
+        )
+    except ReturnCodeAssertionError:
+        should_fail_on_contract_call = True
+    assert should_fail_on_contract_call is True
+
     invoke(
         calls=[(deploy_info["address"], "increase_balance", [10, 20])],
         account_address=PREDEPLOYED_ACCOUNT_ADDRESS,
         private_key=PREDEPLOYED_ACCOUNT_PRIVATE_KEY,
     )
-    # TODO call contract after deploy should fail but should work after create_block_on_demand
-
     latest_block = gateway_call("get_block", blockNumber="latest")
     block_number_after_deploy_and_invoke = latest_block["block_number"]
     assert block_number_after_deploy_and_invoke == 0
 
     requests.post(f"{APP_URL}/create_block_on_demand")
+
+    balance_after_create_block_on_demand = call(
+        function="get_balance",
+        address=deploy_info["address"],
+        abi_path=ABI_PATH,
+    )
+    assert int(balance_after_create_block_on_demand) == 30
+
     latest_block = gateway_call("get_block", blockNumber="latest")
     block_number_after_block_on_demand_call = latest_block["block_number"]
     assert block_number_after_block_on_demand_call == 1
     assert len(latest_block["transactions"]) == 2
+
 
 @devnet_in_background(
     *[
@@ -59,6 +76,8 @@ def test_blocks_on_demand_invoke_call():
     """Test deploy in blocks on demand mode for invoke and contract call"""
     # Deploy and invoke
     deploy_info = deploy(CONTRACT_PATH, inputs=["0"])
+    requests.post(f"{APP_URL}/create_block_on_demand")
+
     balance_after_deploy = call(
         function="get_balance",
         address=deploy_info["address"],

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -16,8 +16,6 @@ from .shared import (
 )
 from .util import deploy, devnet_in_background
 
-CONTRAC_HASH_CLASS = "0x71df7c871d389943e24aaaf85d41594266d12f2f9b580a9f92ba4a0bf763d67"
-
 
 @devnet_in_background(
     *[
@@ -49,4 +47,3 @@ def test_blocks_on_demand():
     assert block_number_after_deploy_and_invoke == 0
     assert block_number_after_block_on_demand_call == 1
     assert len(latest_block["transactions"]) == 2
-    assert latest_block["transactions"][0]["class_hash"] == CONTRAC_HASH_CLASS

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -9,12 +9,13 @@ import requests
 from .account import invoke
 from .settings import APP_URL
 from .shared import (
+    ABI_PATH,
     CONTRACT_PATH,
     PREDEPLOY_ACCOUNT_CLI_ARGS,
     PREDEPLOYED_ACCOUNT_ADDRESS,
     PREDEPLOYED_ACCOUNT_PRIVATE_KEY,
 )
-from .util import deploy, devnet_in_background
+from .util import call, deploy, devnet_in_background
 
 
 @devnet_in_background(
@@ -23,10 +24,11 @@ from .util import deploy, devnet_in_background
         "--blocks-on-demand",
     ]
 )
-def test_blocks_on_demand():
+def test_blocks_on_demand_invoke():
     """Test deploy in blocks on demand mode"""
     latest_block = gateway_call("get_block", blockNumber="latest")
     genesis_block_number = latest_block["block_number"]
+    assert genesis_block_number == 0
 
     # Deploy and invoke
     deploy_info = deploy(CONTRACT_PATH, inputs=["0"])
@@ -35,15 +37,51 @@ def test_blocks_on_demand():
         account_address=PREDEPLOYED_ACCOUNT_ADDRESS,
         private_key=PREDEPLOYED_ACCOUNT_PRIVATE_KEY,
     )
+    # TODO call contract after deploy should fail but should work after create_block_on_demand
 
     latest_block = gateway_call("get_block", blockNumber="latest")
     block_number_after_deploy_and_invoke = latest_block["block_number"]
+    assert block_number_after_deploy_and_invoke == 0
 
     requests.post(f"{APP_URL}/create_block_on_demand")
     latest_block = gateway_call("get_block", blockNumber="latest")
     block_number_after_block_on_demand_call = latest_block["block_number"]
-
-    assert genesis_block_number == 0
-    assert block_number_after_deploy_and_invoke == 0
     assert block_number_after_block_on_demand_call == 1
     assert len(latest_block["transactions"]) == 2
+
+@devnet_in_background(
+    *[
+        *PREDEPLOY_ACCOUNT_CLI_ARGS,
+        "--blocks-on-demand",
+    ]
+)
+def test_blocks_on_demand_invoke_call():
+    """Test deploy in blocks on demand mode for invoke and contract call"""
+    # Deploy and invoke
+    deploy_info = deploy(CONTRACT_PATH, inputs=["0"])
+    balance_after_deploy = call(
+        function="get_balance",
+        address=deploy_info["address"],
+        abi_path=ABI_PATH,
+    )
+    assert int(balance_after_deploy) == 0
+
+    invoke(
+        calls=[(deploy_info["address"], "increase_balance", [10, 20])],
+        account_address=PREDEPLOYED_ACCOUNT_ADDRESS,
+        private_key=PREDEPLOYED_ACCOUNT_PRIVATE_KEY,
+    )
+    balance_after_invoke = call(
+        function="get_balance",
+        address=deploy_info["address"],
+        abi_path=ABI_PATH,
+    )
+    assert int(balance_after_invoke) == 0
+
+    requests.post(f"{APP_URL}/create_block_on_demand")
+    balance_after_create_block_on_demand = call(
+        function="get_balance",
+        address=deploy_info["address"],
+        abi_path=ABI_PATH,
+    )
+    assert int(balance_after_create_block_on_demand) == 30

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -2,8 +2,9 @@
 Test blocks on demand mode.
 """
 
-import requests
 from test.rpc.rpc_utils import gateway_call
+
+import requests
 
 from .account import invoke
 from .settings import APP_URL
@@ -13,15 +14,17 @@ from .shared import (
     PREDEPLOYED_ACCOUNT_ADDRESS,
     PREDEPLOYED_ACCOUNT_PRIVATE_KEY,
 )
-from .util import (
-    deploy,
-    devnet_in_background,
-)
+from .util import deploy, devnet_in_background
 
 CONTRAC_HASH_CLASS = "0x71df7c871d389943e24aaaf85d41594266d12f2f9b580a9f92ba4a0bf763d67"
 
 
-@devnet_in_background(*[*PREDEPLOY_ACCOUNT_CLI_ARGS,"--blocks-on-demand",])
+@devnet_in_background(
+    *[
+        *PREDEPLOY_ACCOUNT_CLI_ARGS,
+        "--blocks-on-demand",
+    ]
+)
 def test_blocks_on_demand():
     """Test deploy in blocks on demand mode"""
     latest_block = gateway_call("get_block", blockNumber="latest")

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -34,16 +34,14 @@ def test_blocks_on_demand_invoke():
     deploy_info = deploy(CONTRACT_PATH, inputs=["0"])
     assert_tx_status(deploy_info["tx_hash"], "RECEIVED")
 
-    should_fail_on_contract_call = False
     try:
         call(
             function="get_balance",
             address=deploy_info["address"],
             abi_path=ABI_PATH,
         )
-    except ReturnCodeAssertionError:
-        should_fail_on_contract_call = True
-    assert should_fail_on_contract_call is True
+    except ReturnCodeAssertionError as error:
+        assert "StarknetErrorCode.UNINITIALIZED_CONTRACT" in str(error)
 
     invoke(
         calls=[(deploy_info["address"], "increase_balance", [10, 20])],

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -5,29 +5,45 @@ Test blocks on demand mode.
 import requests
 from test.rpc.rpc_utils import gateway_call
 
+from .account import invoke
 from .settings import APP_URL
 from .shared import (
     CONTRACT_PATH,
     PREDEPLOY_ACCOUNT_CLI_ARGS,
+    PREDEPLOYED_ACCOUNT_ADDRESS,
+    PREDEPLOYED_ACCOUNT_PRIVATE_KEY,
 )
 from .util import (
     deploy,
     devnet_in_background,
 )
 
+CONTRAC_HASH_CLASS = "0x71df7c871d389943e24aaaf85d41594266d12f2f9b580a9f92ba4a0bf763d67"
+
+
 @devnet_in_background(*[*PREDEPLOY_ACCOUNT_CLI_ARGS,"--blocks-on-demand",])
 def test_blocks_on_demand():
     """Test deploy in blocks on demand mode"""
     latest_block = gateway_call("get_block", blockNumber="latest")
-    block_number_before_deploy = latest_block["block_number"]
-    deploy(contract=CONTRACT_PATH)
+    genesis_block_number = latest_block["block_number"]
+
+    # Deploy and invoke
+    deploy_info = deploy(CONTRACT_PATH, inputs=["0"])
+    invoke(
+        calls=[(deploy_info["address"], "increase_balance", [10, 20])],
+        account_address=PREDEPLOYED_ACCOUNT_ADDRESS,
+        private_key=PREDEPLOYED_ACCOUNT_PRIVATE_KEY,
+    )
+
     latest_block = gateway_call("get_block", blockNumber="latest")
-    block_number_after_deploy = latest_block["block_number"]
+    block_number_after_deploy_and_invoke = latest_block["block_number"]
 
     requests.post(f"{APP_URL}/create_block_on_demand")
     latest_block = gateway_call("get_block", blockNumber="latest")
     block_number_after_block_on_demand_call = latest_block["block_number"]
 
-    assert block_number_before_deploy == 0
-    assert block_number_after_deploy == 0
+    assert genesis_block_number == 0
+    assert block_number_after_deploy_and_invoke == 0
     assert block_number_after_block_on_demand_call == 1
+    assert len(latest_block["transactions"]) == 2
+    assert latest_block["transactions"][0]["class_hash"] == CONTRAC_HASH_CLASS

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -15,7 +15,13 @@ from .shared import (
     PREDEPLOYED_ACCOUNT_ADDRESS,
     PREDEPLOYED_ACCOUNT_PRIVATE_KEY,
 )
-from .util import ReturnCodeAssertionError, call, deploy, devnet_in_background
+from .util import (
+    ReturnCodeAssertionError,
+    assert_tx_status,
+    call,
+    deploy,
+    devnet_in_background,
+)
 
 
 @devnet_in_background(*PREDEPLOY_ACCOUNT_CLI_ARGS, "--blocks-on-demand")
@@ -26,6 +32,8 @@ def test_blocks_on_demand_invoke():
     assert genesis_block_number == 0
 
     deploy_info = deploy(CONTRACT_PATH, inputs=["0"])
+    assert_tx_status(deploy_info["tx_hash"], "RECEIVED")
+
     should_fail_on_contract_call = False
     try:
         call(

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -4,6 +4,7 @@ Test blocks on demand mode.
 
 from test.rpc.rpc_utils import gateway_call
 
+import pytest
 import requests
 
 from .account import invoke
@@ -40,6 +41,7 @@ def test_blocks_on_demand_invoke():
             address=deploy_info["address"],
             abi_path=ABI_PATH,
         )
+        pytest.fail("Should have failed")
     except ReturnCodeAssertionError as error:
         assert "StarknetErrorCode.UNINITIALIZED_CONTRACT" in str(error)
 


### PR DESCRIPTION
## Usage related changes

- Granular block generation added via `--blocks-on-demand` mode and `create_block_on_demand` endpoint. The genesis block will be added normally.

## Development related changes

- `generate` method in `DevnetBlocks` class was changed to accept a list of transactions

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
