### PR TITLE
Move warn

### DIFF
--- a/starknet_devnet/__init__.py
+++ b/starknet_devnet/__init__.py
@@ -11,8 +11,6 @@ from crypto_cpp_py.cpp_bindings import cpp_hash
 from starkware.crypto.signature.fast_pedersen_hash import pedersen_hash
 from starkware.starknet.services.api.contract_class import ContractClass
 
-from .util import warn
-
 __version__ = "0.4.3"
 
 
@@ -56,6 +54,9 @@ if _cairo_vm == "rust":
     from starknet_devnet.cairo_rs_py_patch import cairo_rs_py_monkeypatch
 
     cairo_rs_py_monkeypatch()
+
+    from .util import warn
+
     warn("Using Cairo VM: Rust")
 
 elif not _cairo_vm or _cairo_vm == "python":


### PR DESCRIPTION
## Usage related changes

- Close #380 (although I don't completely understand why this PR helps)

## Development related changes

- In `__init__.py`, execute `from .util import warn` only before `warn` is called

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing
