### PR TITLE
Unification of create_block_on_demand() to create_block()

### DIFF
--- a/page/docs/guide/blocks.md
+++ b/page/docs/guide/blocks.md
@@ -19,32 +19,20 @@ POST /create_block
 Response:
 
 ```
-{
-    "transactions": [],
-    "parent_block_hash": "0x0",
-    "timestamp": 1659457385,
-    "state_root": "004bee3ee...",
-    "gas_price": "0x174876e800",
-    "sequencer_address": "0x4bbfb0d1aa...",
-    "transaction_receipts": [],
-    "starknet_version": "0.9.1",
-    "block_hash": "0x1",
-    "block_number": 1,
-    "status": "ACCEPTED_ON_L2"
-}
+{'block_hash': '0x115e1b390cafa7942b6ab141ab85040defe7dee9bef3bc31d8b5b3d01cc9c67'}
 ```
 
 ### Create a block on demand
 
 If you start Devnet with `--blocks-on-demand` CLI option, all transactions will be pending and stored in a pending block (targetable via block ID `"pending"`).
-To create a block on demand, send a `POST` request to `/create_block_on_demand`. This will convert the pending block to the latest block (targetable via block ID `"latest"`), giving it a block hash and a block number. All subsequent transactions will be stored to a new pending block.
+To create a block on demand, send a `POST` request to `/create_block`. This will convert the pending block to the latest block (targetable via block ID `"latest"`), giving it a block hash and a block number. All subsequent transactions will be stored to a new pending block.
 
 In case of demanding block creation with no pending transactions, a new empty block will be generated.
 
 The creation of the genesis block is not affected by this feature.
 
 ```
-POST /create_block_on_demand
+POST /create_block
 ```
 
 Response:

--- a/page/docs/guide/run.md
+++ b/page/docs/guide/run.md
@@ -25,7 +25,7 @@ optional arguments:
                         Specify the path to dump to
   --dump-on DUMP_ON     Specify when to dump; can dump on: exit, transaction
   --lite-mode           Introduces speed-up by skipping block hash calculation - applies sequential numbering instead (0x0, 0x1, 0x2, ...).
-  --blocks-on-demand    Introduces block generation on demand via /create_block_on_demand endpoint
+  --blocks-on-demand    Introduces block generation on demand via /create_block endpoint
   --accounts ACCOUNTS   Specify the number of accounts to be predeployed; defaults to 10
   --initial-balance INITIAL_BALANCE, -e INITIAL_BALANCE
                         Specify the initial balance of accounts to be predeployed; defaults to 1e+21

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -190,14 +190,7 @@ async def mint():
 
 @base.route("/create_block", methods=["POST"])
 async def create_block():
-    """Create empty block"""
-    block = await state.starknet_wrapper.create_empty_block()
-    return Response(block.dumps(), status=200, mimetype="application/json")
-
-
-@base.route("/create_block_on_demand", methods=["POST"])
-async def create_block_on_demand():
-    """Create block on demand"""
+    """Create block with pending transactions."""
     block = await state.starknet_wrapper.generate_latest_block()
 
     return jsonify({"block_hash": hex(block.block_hash)})

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -712,7 +712,7 @@ class StarknetWrapper:
 
     async def generate_latest_block(self, block_hash=None) -> StarknetBlock:
         """
-        Generate new block with pending transactions.
+        Generate new block with pending transactions or empty block.
         Block hash can be specified in special cases.
         """
 

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -712,7 +712,7 @@ class StarknetWrapper:
 
     async def generate_latest_block(self, block_hash=None) -> StarknetBlock:
         """
-        Generate new block with pending transactions in --blocks-on-demand mode.
+        Generate new block with pending transactions.
         Block hash can be specified in special cases.
         """
 

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -81,8 +81,8 @@ def test_invokable_on_pending_block():
     demand_block_creation()
     assert_tx_status(invoke_hash, "ACCEPTED_ON_L2")
 
-    balance_after_create_block_on_demand = get_contract_balance()
-    assert int(balance_after_create_block_on_demand) == 30
+    balance_after_create_block = get_contract_balance()
+    assert int(balance_after_create_block) == 30
 
     latest_block = get_block(block_number="latest", parse=True)
     block_number_after_block_on_demand_call = latest_block["block_number"]
@@ -118,7 +118,7 @@ def test_calling_works_after_block_creation():
     """
     Test deploy in blocks-on-demand mode for invoke and contract call.
     Balance after invoke should be 0 even when we increased it.
-    Only after calling create_block_on_demand balance should be increased in this mode.
+    Only after calling create_block balance should be increased in this mode.
     """
     # Deploy and invoke
     deploy_info = deploy(CONTRACT_PATH, inputs=["0"])
@@ -144,8 +144,8 @@ def test_calling_works_after_block_creation():
     assert int(balance_after_invoke) == 0
 
     demand_block_creation()
-    balance_after_create_block_on_demand = get_contract_balance()
-    assert int(balance_after_create_block_on_demand) == 30
+    balance_after_create_block = get_contract_balance()
+    assert int(balance_after_create_block) == 30
 
 
 @devnet_in_background(*PREDEPLOY_ACCOUNT_CLI_ARGS, "--blocks-on-demand")

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -302,7 +302,8 @@ def test_create_block_endpoint():
     assert resp.get("block_hash") == GENESIS_BLOCK_HASH
     assert resp.get("block_number") == GENESIS_BLOCK_NUMBER
 
-    resp = create_empty_block()
+    create_empty_block()
+    resp = get_block_by_number({"blockNumber": "latest"}).json()
     assert resp.get("block_number") == GENESIS_BLOCK_NUMBER + 1
     assert resp.get("block_hash") == hex(GENESIS_BLOCK_NUMBER + 1)
     assert resp.get("status") == "ACCEPTED_ON_L2"
@@ -313,7 +314,8 @@ def test_create_block_endpoint():
     resp = get_block_by_number({"blockNumber": "latest"}).json()
     assert resp.get("block_number") == GENESIS_BLOCK_NUMBER + 2
 
-    resp = create_empty_block()
+    create_empty_block()
+    resp = get_block_by_number({"blockNumber": "latest"}).json()
     assert resp.get("block_number") == GENESIS_BLOCK_NUMBER + 3
     assert resp.get("block_hash") == hex(GENESIS_BLOCK_NUMBER + 3)
 

--- a/test/util.py
+++ b/test/util.py
@@ -733,4 +733,4 @@ class ErrorExpector:
 
 def demand_block_creation():
     """Demand block creation. Useful when devnet started with --blocks-on-demand"""
-    return requests.post(f"{APP_URL}/create_block_on_demand")
+    return requests.post(f"{APP_URL}/create_block")


### PR DESCRIPTION
## Usage related changes

- `create_block` endpoint was unified with `create_block_on_demand`, from now on `create_block` will return only block hash

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `./scripts/test.sh`
