### PR TITLE
Make number of retries in forking configurable

### DIFF
--- a/page/docs/guide/fork.md
+++ b/page/docs/guide/fork.md
@@ -14,7 +14,7 @@ The value of `--fork-network` can either be a network name (`alpha-goerli`, `alp
 
 The `--fork-block` parameter is optional and its value should be the block number from which the forking is done. If none is provided, defaults to the `"latest"` block at the time of Devnet's start-up.
 
-You can use the `--fork-retries` parameter to specify the number of retries of failed HTTP requests sent to the network before giving up, set to `-1` for unlimited retries, defaults to `1`
+You can use the `--fork-retries` parameter to specify the number of retries of failed HTTP requests sent to the network before giving up, defaults to `1`
 
 All calls will first try Devnet's state and then fall back to the forking block.
 

--- a/page/docs/guide/fork.md
+++ b/page/docs/guide/fork.md
@@ -7,12 +7,14 @@ sidebar_position: 16
 To interact with contracts deployed on mainnet or testnet, you can use the forking feature to copy the remote origin and experiment with it locally with no changes to the origin.
 
 ```
-starknet-devnet --fork-network <NAME|URL> [--fork-block <BLOCK_NUMBER>]
+starknet-devnet --fork-network <NAME|URL> [--fork-block <BLOCK_NUMBER>] [--fork-retries <NUMBER>]
 ```
 
 The value of `--fork-network` can either be a network name (`alpha-goerli`, `alpha-goerli2`, or `alpha-mainnet`) or a URL (e.g. `https://alpha4.starknet.io`).
 
 The `--fork-block` parameter is optional and its value should be the block number from which the forking is done. If none is provided, defaults to the `"latest"` block at the time of Devnet's start-up.
+
+You can use the `--fork-retries` parameter to specify the number of retries of failed HTTP requests sent to the network before giving up, set to `-1` for unlimited retries, defaults to `1`
 
 All calls will first try Devnet's state and then fall back to the forking block.
 

--- a/page/docs/guide/run.md
+++ b/page/docs/guide/run.md
@@ -48,7 +48,7 @@ optional arguments:
   --fork-block FORK_BLOCK
                         Specify the block number where the --fork-network is forked; defaults to latest
   --fork-retries FORK_RETRIES
-                        Specify the number of retries of failed HTTP requests sent to the network before giving up, set to -1 for unlimited retries, defaults to 1
+                        Specify the number of retries of failed HTTP requests sent to the network before giving up, defaults to 1
   --chain-id CHAIN_ID   Specify the chain id as string: {MAINNET, TESTNET, TESTNET2}
   --disable-rpc-request-validation
                         Disable requests schema validation for RPC endpoints

--- a/page/docs/guide/run.md
+++ b/page/docs/guide/run.md
@@ -7,10 +7,12 @@ sidebar_position: 1
 Installing the package adds the `starknet-devnet` command.
 
 ```text
-usage: starknet-devnet [-h] [-v] [--host HOST] [--port PORT] [--load-path LOAD_PATH] [--dump-path DUMP_PATH] [--dump-on DUMP_ON] [--lite-mode] [--accounts ACCOUNTS]
-                       [--initial-balance INITIAL_BALANCE] [--seed SEED] [--hide-predeployed-accounts] [--start-time START_TIME] [--gas-price GAS_PRICE] [--allow-max-fee-zero]
+usage: starknet-devnet [-h] [-v] [--host HOST] [--port PORT] [--load-path LOAD_PATH] [--dump-path DUMP_PATH] [--dump-on DUMP_ON]
+                       [--lite-mode] [--blocks-on-demand] [--accounts ACCOUNTS] [--initial-balance INITIAL_BALANCE] [--seed SEED]
+                       [--hide-predeployed-accounts] [--start-time START_TIME] [--gas-price GAS_PRICE] [--allow-max-fee-zero]
                        [--timeout TIMEOUT] [--account-class ACCOUNT_CLASS] [--fork-network FORK_NETWORK] [--fork-block FORK_BLOCK]
-                       [--chain-id CHAIN_ID] [--blocks-on-demand]
+                       [--fork-retries FORK_RETRIES] [--chain-id CHAIN_ID] [--disable-rpc-request-validation]
+                       [--disable-rpc-response-validation]
 
 Run a local instance of StarkNet Devnet
 
@@ -25,7 +27,7 @@ optional arguments:
                         Specify the path to dump to
   --dump-on DUMP_ON     Specify when to dump; can dump on: exit, transaction
   --lite-mode           Introduces speed-up by skipping block hash calculation - applies sequential numbering instead (0x0, 0x1, 0x2, ...).
-  --blocks-on-demand    Introduces block generation on demand via /create_block endpoint
+  --blocks-on-demand    Block generation on demand via an endpoint.
   --accounts ACCOUNTS   Specify the number of accounts to be predeployed; defaults to 10
   --initial-balance INITIAL_BALANCE, -e INITIAL_BALANCE
                         Specify the initial balance of accounts to be predeployed; defaults to 1e+21
@@ -40,13 +42,14 @@ optional arguments:
   --timeout TIMEOUT, -t TIMEOUT
                         Specify the server timeout in seconds; defaults to 60
   --account-class ACCOUNT_CLASS
-                        Specify the account implementation to be used for predeploying; should be a path to the compiled JSON artifact; defaults to OpenZeppelin v0.5.1
+                        Specify the account implementation to be used for predeploying; should be a path to the compiled JSON artifact; defaults to OpenZeppelin v1
   --fork-network FORK_NETWORK
                         Specify the network to fork: can be a URL (e.g. https://alpha-mainnet.starknet.io) or network name (valid names: alpha-goerli, alpha-goerli2, alpha-mainnet)
   --fork-block FORK_BLOCK
                         Specify the block number where the --fork-network is forked; defaults to latest
-  --chain-id CHAIN_ID
-                        Specify the chain id as string: {MAINNET, TESTNET, TESTNET2}
+  --fork-retries FORK_RETRIES
+                        Specify the number of retries of failed HTTP requests sent to the network before giving up, set to -1 for unlimited retries, defaults to 1
+  --chain-id CHAIN_ID   Specify the chain id as string: {MAINNET, TESTNET, TESTNET2}
   --disable-rpc-request-validation
                         Disable requests schema validation for RPC endpoints
   --disable-rpc-response-validation

--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -186,19 +186,21 @@ class NonNegativeAction(argparse.Action):
         setattr(namespace, self.dest, value)
 
 
-class ForkRetriesAction(argparse.Action):
+class PositiveAction(argparse.Action):
     """
-    Action for parsing the --fork-retries int argument, it should be -1, 0 or positive int.
+    Action for parsing positive int argument;
     """
 
     def __call__(self, parser, namespace, values, option_string=None):
-        error_msg = f"argument {option_string} must be either a positive int or equals to -1; got: {values}."
+        error_msg = (
+            f"argument {option_string} must be a positive integer; got: {values}."
+        )
         try:
             value = int(values)
         except ValueError:
             parser.error(error_msg)
 
-        if not (value > 0 or value == -1):
+        if value <= 0:
             parser.error(error_msg)
 
         setattr(namespace, self.dest, value)
@@ -322,8 +324,8 @@ def parse_args(raw_args: List[str]):
         "--fork-retries",
         type=int,
         default=1,
-        action=ForkRetriesAction,
-        help="Specify the number of retries of failed HTTP requests sent to the network before giving up, set to -1 for unlimited retries, defaults to 1",
+        action=PositiveAction,
+        help="Specify the number of retries of failed HTTP requests sent to the network before giving up, defaults to 1",
     )
     parser.add_argument(
         "--chain-id",

--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -359,6 +359,7 @@ class DevnetConfig:
         self.hide_predeployed_accounts = self.args.hide_predeployed_accounts
         self.fork_network = self.args.fork_network
         self.fork_block = self.args.fork_block
+        self.fork_retries = self.args.fork_retries
         self.chain_id = self.args.chain_id
         self.validate_rpc_requests = not self.args.disable_rpc_request_validation
         self.validate_rpc_responses = not self.args.disable_rpc_response_validation

--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -304,7 +304,7 @@ def parse_args(raw_args: List[str]):
         "--fork-retry",
         type=int,
         default=1,
-        help="Specify the number of retries when forking --fork-network; defaults to 1",
+        help="Specify the number of retries of failed HTTP requests sent to the network before giving up, set to -1 for unlimited retries, defaults to 1",
     )
     parser.add_argument(
         "--chain-id",

--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -137,12 +137,12 @@ def _parse_account_class(class_path: str) -> ContractClassWrapper:
     return ContractClassWrapper(contract_class, class_hash_bytes)
 
 
-def _get_feeder_gateway_client(url: str, block_id: str):
+def _get_feeder_gateway_client(url: str, block_id: str, n_retries: int = 1):
     """Construct a feeder gateway client at url and block"""
 
     feeder_gateway_client = FeederGatewayClient(
         url=url,
-        retry_config=RetryConfig(n_retries=1),
+        retry_config=RetryConfig(n_retries=n_retries),
     )
 
     try:
@@ -301,6 +301,12 @@ def parse_args(raw_args: List[str]):
         help="Specify the block number where the --fork-network is forked; defaults to latest",
     )
     parser.add_argument(
+        "--fork-retry",
+        type=int,
+        default=1,
+        help="Specify the number of retries when forking --fork-network; defaults to 1",
+    )
+    parser.add_argument(
         "--chain-id",
         type=_chain_id,
         default=StarknetChainId.TESTNET,
@@ -327,7 +333,7 @@ def parse_args(raw_args: List[str]):
     if parsed_args.fork_network:
         parsed_args.fork_block = parsed_args.fork_block or "latest"
         parsed_args.fork_network, parsed_args.fork_block = _get_feeder_gateway_client(
-            parsed_args.fork_network, parsed_args.fork_block
+            parsed_args.fork_network, parsed_args.fork_block, parsed_args.fork_retry
         )
 
     return parsed_args

--- a/test/test_fork_cli_params.py
+++ b/test/test_fork_cli_params.py
@@ -137,3 +137,65 @@ def test_valid_block_ids(fork_block: str):
     terminate_and_wait(proc)
     assert f"Forking {ALPHA_GOERLI2_URL}" in read_stream(proc.stdout)
     assert proc.returncode == 0
+
+
+@pytest.mark.parametrize("fork_retries", ["-2", "0"])
+def test_out_of_range_fork_retries(fork_retries: str):
+    """Should exit if provided with a negative block number"""
+    proc = ACTIVE_DEVNET.start(
+        "--fork-network",
+        "alpha-goerli",
+        "--fork-retries",
+        fork_retries,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+    )
+    assert read_stream(proc.stdout) == ""
+    assert (
+        f"error: argument --fork-retries must be either a positive int or equals to -1; got: {fork_retries}.\n"
+        in read_stream(proc.stderr)
+    )
+
+    assert proc.returncode == 2
+
+
+def test_invalid_fork_retries():
+    """Should exit if provided with non integer"""
+    fork_retries = "invalid"
+
+    proc = ACTIVE_DEVNET.start(
+        "--fork-network",
+        "alpha-goerli",
+        "--fork-retries",
+        fork_retries,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+    )
+    assert read_stream(proc.stdout) == ""
+    assert (
+        f"error: argument --fork-retries: invalid int value: '{fork_retries}'\n"
+        in read_stream(proc.stderr)
+    )
+
+    assert proc.returncode == 2
+
+@pytest.mark.parametrize(
+    "fork_retries",
+    [
+        "1",
+        "3",
+        "-1",
+    ],
+)
+def test_valid_fork_retries(fork_retries: str):
+    """Test some happy path fork retries values"""
+    proc = ACTIVE_DEVNET.start(
+        "--fork-network",
+        "alpha-goerli2",
+        "--fork-retries",
+        fork_retries,
+        stdout=subprocess.PIPE,
+    )
+    terminate_and_wait(proc)
+    assert f"Forking {ALPHA_GOERLI2_URL}" in read_stream(proc.stdout)
+    assert proc.returncode == 0

--- a/test/test_fork_cli_params.py
+++ b/test/test_fork_cli_params.py
@@ -139,7 +139,7 @@ def test_valid_block_ids(fork_block: str):
     assert proc.returncode == 0
 
 
-@pytest.mark.parametrize("fork_retries", ["-2", "0"])
+@pytest.mark.parametrize("fork_retries", ["-1", "0"])
 def test_out_of_range_fork_retries(fork_retries: str):
     """Should exit if provided with a negative block number"""
     proc = ACTIVE_DEVNET.start(
@@ -152,7 +152,7 @@ def test_out_of_range_fork_retries(fork_retries: str):
     )
     assert read_stream(proc.stdout) == ""
     assert (
-        f"error: argument --fork-retries must be either a positive int or equals to -1; got: {fork_retries}.\n"
+        f"error: argument --fork-retries must be a positive integer; got: {fork_retries}.\n"
         in read_stream(proc.stderr)
     )
 
@@ -179,12 +179,12 @@ def test_invalid_fork_retries():
 
     assert proc.returncode == 2
 
+
 @pytest.mark.parametrize(
     "fork_retries",
     [
         "1",
         "3",
-        "-1",
     ],
 )
 def test_valid_fork_retries(fork_retries: str):


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

- The user could specify the number of retries using `--fork-retry NUMBER` with the default value of 1.
- Close #396 

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

None

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `./scripts/test.sh`
