### PR TITLE
Fix JSON spec for starknet address too restrictive

### DIFF
--- a/starknet_devnet/blueprints/rpc/rpc_spec.py
+++ b/starknet_devnet/blueprints/rpc/rpc_spec.py
@@ -934,7 +934,7 @@ RPC_SPECIFICATION = r"""
                 "title": "Field element",
                 "$comment": "A field element, represented as a string of hex digits",
                 "description": "A field element. Represented as up to 63 hex digits and leading 4 bits zeroed.",
-                "pattern": "^0x0[a-fA-F0-9]{1,63}$"
+                "pattern": "^0x0?[a-fA-F0-9]{1,63}$"
             },
             "BLOCK_NUMBER": {
                 "description": "The block's number (its height)",

--- a/test/rpc/rpc_utils.py
+++ b/test/rpc/rpc_utils.py
@@ -115,4 +115,4 @@ def is_felt(value: str) -> bool:
     """
     Check whether value is a Felt
     """
-    return bool(re.match(r"^0x0[a-fA-F0-9]{1,63}$", value))
+    return bool(re.match(r"^0x0?[a-fA-F0-9]{1,63}$", value))


### PR DESCRIPTION
## Usage related changes

- Allow address without leading 0 (ie address in hex string and not especially bytes string)

Resolves https://github.com/Shard-Labs/starknet-devnet/issues/401

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `./scripts/test.sh`

Note: can't run test suite locally

```
 jq: error: Could not open file test/artifacts/contracts/cairo/contract.cairo/contract.json: No such file or directory
```

but tried the updated regex with the dedicated test on addresses with and without the leading `0`