### PR TITLE
increase/set time block creation

### DIFF
--- a/page/docs/guide/advancing-time.md
+++ b/page/docs/guide/advancing-time.md
@@ -7,7 +7,7 @@ Block timestamp can be manipulated by setting the exact time or setting the time
 
 ## Set time
 
-Sets the exact time and generate a new block. All subsequent blocks will keep the set offset.
+Sets the exact time and generates a new block (only possible if there are no pending transactions). All subsequent blocks will keep the set offset.
 
 ```
 POST /set_time
@@ -20,7 +20,7 @@ Warning: block time can be set in the past and lead to unexpected behaviour!
 
 ## Increase time
 
-Increases the time offset for each generated block and generate a new block.
+Increases the block timestamp by the provided amount and generates a new block (only possible if there are no pending transactions). All subsequent blocks will keep this increment.
 
 ```
 POST /increase_time

--- a/page/docs/guide/advancing-time.md
+++ b/page/docs/guide/advancing-time.md
@@ -7,7 +7,7 @@ Block timestamp can be manipulated by setting the exact time or setting the time
 
 ## Set time
 
-Sets the exact time of the next generated block. All subsequent blocks will keep the set offset.
+Sets the exact time and generate block. All subsequent blocks will keep the set offset.
 
 ```
 POST /set_time
@@ -20,7 +20,7 @@ Warning: block time can be set in the past and lead to unexpected behaviour!
 
 ## Increase time
 
-Increases the time offset for each generated block.
+Increases the time offset for each generated block and generate block.
 
 ```
 POST /increase_time

--- a/page/docs/guide/advancing-time.md
+++ b/page/docs/guide/advancing-time.md
@@ -7,7 +7,7 @@ Block timestamp can be manipulated by setting the exact time or setting the time
 
 ## Set time
 
-Sets the exact time and generate block. All subsequent blocks will keep the set offset.
+Sets the exact time and generate a new block. All subsequent blocks will keep the set offset.
 
 ```
 POST /set_time
@@ -20,7 +20,7 @@ Warning: block time can be set in the past and lead to unexpected behaviour!
 
 ## Increase time
 
-Increases the time offset for each generated block and generate block.
+Increases the time offset for each generated block and generate a new block.
 
 ```
 POST /increase_time

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -134,7 +134,9 @@ async def increase_time():
     state.starknet_wrapper.increase_block_time(time_s)
     block = await state.starknet_wrapper.generate_latest_block()
 
-    return jsonify({"timestamp_increased_by": time_s, "block_hash": hex(block.block_hash)})
+    return jsonify(
+        {"timestamp_increased_by": time_s, "block_hash": hex(block.block_hash)}
+    )
 
 
 @base.route("/set_time", methods=["POST"])

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -138,12 +138,12 @@ async def increase_time():
         return jsonify(
             {"timestamp_increased_by": time_s, "block_hash": hex(block.block_hash)}
         )
-    else:
-        raise StarknetDevnetException(
-            code=StarkErrorCode.MALFORMED_REQUEST,
-            status_code=400,
-            message=f"Block time can be increased only if there are no pending transactions.",
-        )
+
+    raise StarknetDevnetException(
+        code=StarkErrorCode.MALFORMED_REQUEST,
+        status_code=400,
+        message="Block time can be increased only if there are no pending transactions.",
+    )
 
 
 @base.route("/set_time", methods=["POST"])
@@ -156,15 +156,13 @@ async def set_time():
     if not state.starknet_wrapper.pending_txs:
         state.starknet_wrapper.set_block_time(time_s)
         block = await state.starknet_wrapper.generate_latest_block()
-        return jsonify(
-            {"block_timestamp": time_s, "block_hash": hex(block.block_hash)}
-        )
-    else:
-        raise StarknetDevnetException(
-            code=StarkErrorCode.MALFORMED_REQUEST,
-            status_code=400,
-            message=f"Block time can be set only if there are no pending transactions.",
-        )
+        return jsonify({"block_timestamp": time_s, "block_hash": hex(block.block_hash)})
+
+    raise StarknetDevnetException(
+        code=StarkErrorCode.MALFORMED_REQUEST,
+        status_code=400,
+        message="Block time can be set only if there are no pending transactions.",
+    )
 
 
 @base.route("/account_balance", methods=["GET"])

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -131,14 +131,19 @@ async def increase_time():
     request_dict = request.json or {}
     time_s = extract_positive(request_dict, "time")
 
-    state.starknet_wrapper.increase_block_time(time_s)
-    await state.starknet_wrapper.update_pending_state()
-    await state.starknet_wrapper.update_pending_block()
-    block = await state.starknet_wrapper.generate_latest_block()
-
-    return jsonify(
-        {"timestamp_increased_by": time_s, "block_hash": hex(block.block_hash)}
-    )
+    # Increase block time only when there are no pending transactions
+    if not state.starknet_wrapper.pending_txs:
+        state.starknet_wrapper.increase_block_time(time_s)
+        block = await state.starknet_wrapper.generate_latest_block()
+        return jsonify(
+            {"timestamp_increased_by": time_s, "block_hash": hex(block.block_hash)}
+        )
+    else:
+        raise StarknetDevnetException(
+            code=StarkErrorCode.MALFORMED_REQUEST,
+            status_code=400,
+            message=f"Block time can be increased only if there are no pending transactions.",
+        )
 
 
 @base.route("/set_time", methods=["POST"])
@@ -147,12 +152,19 @@ async def set_time():
     request_dict = request.json or {}
     time_s = extract_positive(request_dict, "time")
 
-    state.starknet_wrapper.set_block_time(time_s)
-    await state.starknet_wrapper.update_pending_state()
-    await state.starknet_wrapper.update_pending_block()
-    block = await state.starknet_wrapper.generate_latest_block()
-
-    return jsonify({"block_timestamp": time_s, "block_hash": hex(block.block_hash)})
+    # Set block time only when there are no pending transactions
+    if not state.starknet_wrapper.pending_txs:
+        state.starknet_wrapper.set_block_time(time_s)
+        block = await state.starknet_wrapper.generate_latest_block()
+        return jsonify(
+            {"block_timestamp": time_s, "block_hash": hex(block.block_hash)}
+        )
+    else:
+        raise StarknetDevnetException(
+            code=StarkErrorCode.MALFORMED_REQUEST,
+            status_code=400,
+            message=f"Block time can be set only if there are no pending transactions.",
+        )
 
 
 @base.route("/account_balance", methods=["GET"])

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -132,7 +132,7 @@ async def increase_time():
     time_s = extract_positive(request_dict, "time")
 
     state.starknet_wrapper.increase_block_time(time_s)
-    await state.starknet_wrapper._update_pending_state()
+    await state.starknet_wrapper.update_pending_state()
     await state.starknet_wrapper.update_pending_block()
     block = await state.starknet_wrapper.generate_latest_block()
 
@@ -148,7 +148,7 @@ async def set_time():
     time_s = extract_positive(request_dict, "time")
 
     state.starknet_wrapper.set_block_time(time_s)
-    await state.starknet_wrapper._update_pending_state()
+    await state.starknet_wrapper.update_pending_state()
     await state.starknet_wrapper.update_pending_block()
     block = await state.starknet_wrapper.generate_latest_block()
 

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -134,7 +134,7 @@ async def increase_time():
     state.starknet_wrapper.increase_block_time(time_s)
     block = await state.starknet_wrapper.generate_latest_block()
 
-    return jsonify({"timestamp_increased_by": time_s, "block": hex(block.block_hash)})
+    return jsonify({"timestamp_increased_by": time_s, "block_hash": hex(block.block_hash)})
 
 
 @base.route("/set_time", methods=["POST"])
@@ -146,7 +146,7 @@ async def set_time():
     state.starknet_wrapper.set_block_time(time_s)
     block = await state.starknet_wrapper.generate_latest_block()
 
-    return jsonify({"block_timestamp": time_s, "block": hex(block.block_hash)})
+    return jsonify({"block_timestamp": time_s, "block_hash": hex(block.block_hash)})
 
 
 @base.route("/account_balance", methods=["GET"])

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -127,7 +127,7 @@ def load():
 
 @base.route("/increase_time", methods=["POST"])
 async def increase_time():
-    """Increases the block timestamp offset and generate a block"""
+    """Increases the block timestamp offset and generates a new block"""
     request_dict = request.json or {}
     time_s = extract_positive(request_dict, "time")
 
@@ -140,7 +140,7 @@ async def increase_time():
         )
 
     raise StarknetDevnetException(
-        code=StarkErrorCode.MALFORMED_REQUEST,
+        code=StarkErrorCode.INVALID_REQUEST,
         status_code=400,
         message="Block time can be increased only if there are no pending transactions.",
     )
@@ -148,7 +148,7 @@ async def increase_time():
 
 @base.route("/set_time", methods=["POST"])
 async def set_time():
-    """Sets the block timestamp offset and generate a block"""
+    """Sets the block timestamp offset and generates a new block"""
     request_dict = request.json or {}
     time_s = extract_positive(request_dict, "time")
 

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -143,9 +143,9 @@ async def set_time():
     request_dict = request.json or {}
     time_s = extract_positive(request_dict, "time")
 
-    state.starknet_wrapper.set_next_block_time(time_s)
+    state.starknet_wrapper.set_block_time(time_s)
     block = await state.starknet_wrapper.generate_latest_block()
-    
+
     return jsonify({"block_timestamp": time_s, "block": hex(block.block_hash)})
 
 

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -132,6 +132,8 @@ async def increase_time():
     time_s = extract_positive(request_dict, "time")
 
     state.starknet_wrapper.increase_block_time(time_s)
+    await state.starknet_wrapper._update_pending_state()
+    await state.starknet_wrapper.update_pending_block()
     block = await state.starknet_wrapper.generate_latest_block()
 
     return jsonify(
@@ -146,6 +148,8 @@ async def set_time():
     time_s = extract_positive(request_dict, "time")
 
     state.starknet_wrapper.set_block_time(time_s)
+    await state.starknet_wrapper._update_pending_state()
+    await state.starknet_wrapper.update_pending_block()
     block = await state.starknet_wrapper.generate_latest_block()
 
     return jsonify({"block_timestamp": time_s, "block_hash": hex(block.block_hash)})

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -127,7 +127,7 @@ def load():
 
 @base.route("/increase_time", methods=["POST"])
 async def increase_time():
-    """Increases the block timestamp offset"""
+    """Increases the block timestamp offset and generate block"""
     request_dict = request.json or {}
     time_s = extract_positive(request_dict, "time")
 
@@ -143,7 +143,7 @@ async def increase_time():
 
 @base.route("/set_time", methods=["POST"])
 async def set_time():
-    """Sets the block timestamp offset"""
+    """Sets the block timestamp offset and generate block"""
     request_dict = request.json or {}
     time_s = extract_positive(request_dict, "time")
 

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -127,7 +127,7 @@ def load():
 
 @base.route("/increase_time", methods=["POST"])
 async def increase_time():
-    """Increases the block timestamp offset and generate block"""
+    """Increases the block timestamp offset and generate a block"""
     request_dict = request.json or {}
     time_s = extract_positive(request_dict, "time")
 
@@ -143,7 +143,7 @@ async def increase_time():
 
 @base.route("/set_time", methods=["POST"])
 async def set_time():
-    """Sets the block timestamp offset and generate block"""
+    """Sets the block timestamp offset and generate a block"""
     request_dict = request.json or {}
     time_s = extract_positive(request_dict, "time")
 

--- a/starknet_devnet/blueprints/base.py
+++ b/starknet_devnet/blueprints/base.py
@@ -126,25 +126,27 @@ def load():
 
 
 @base.route("/increase_time", methods=["POST"])
-def increase_time():
+async def increase_time():
     """Increases the block timestamp offset"""
     request_dict = request.json or {}
     time_s = extract_positive(request_dict, "time")
 
     state.starknet_wrapper.increase_block_time(time_s)
+    block = await state.starknet_wrapper.generate_latest_block()
 
-    return jsonify({"timestamp_increased_by": time_s})
+    return jsonify({"timestamp_increased_by": time_s, "block": hex(block.block_hash)})
 
 
 @base.route("/set_time", methods=["POST"])
-def set_time():
+async def set_time():
     """Sets the block timestamp offset"""
     request_dict = request.json or {}
     time_s = extract_positive(request_dict, "time")
 
-    state.starknet_wrapper.set_block_time(time_s)
-
-    return jsonify({"next_block_timestamp": time_s})
+    state.starknet_wrapper.set_next_block_time(time_s)
+    block = await state.starknet_wrapper.generate_latest_block()
+    
+    return jsonify({"block_timestamp": time_s, "block": hex(block.block_hash)})
 
 
 @base.route("/account_balance", methods=["GET"])

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -256,6 +256,9 @@ class StarknetWrapper:
         visited_storage_entries: Set[StorageEntry] = None,
         nonces: Dict[int, int] = None,
     ):
+        """
+        Update pending state.
+        """
         # defaulting
         deployed_contracts = deployed_contracts or []
         explicitly_declared_contracts = explicitly_declared_contracts or []

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -199,7 +199,7 @@ class StarknetWrapper:
 
         self._update_block_number()
         state = self.get_state()
-        state_update = await self._update_pending_state()
+        state_update = await self.update_pending_state()
         await self.blocks.generate_pending(transactions, state, state_update)
         block = await self.generate_latest_block(block_hash=0)
 
@@ -210,7 +210,7 @@ class StarknetWrapper:
     async def create_empty_block(self) -> StarknetBlock:
         """Create empty block."""
         self._update_block_number()
-        state_update = await self._update_pending_state()
+        state_update = await self.update_pending_state()
         self.__latest_state = self.get_state().copy()
         return await self.blocks.generate_empty_block(self.get_state(), state_update)
 
@@ -249,7 +249,7 @@ class StarknetWrapper:
         """
         return self.starknet.state
 
-    async def _update_pending_state(
+    async def update_pending_state(
         self,
         deployed_contracts: List[DeployedContract] = None,
         explicitly_declared_contracts: List[int] = None,
@@ -418,7 +418,7 @@ class StarknetWrapper:
                             self.deployed_contracts,
                         )
 
-                    state_update = await self.starknet_wrapper._update_pending_state(
+                    state_update = await self.starknet_wrapper.update_pending_state(
                         deployed_contracts=self.deployed_contracts,
                         visited_storage_entries=self.visited_storage_entries,
                         explicitly_declared_contracts=self.explicitly_declared,

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -393,6 +393,6 @@ def test_set_time_in_block_on_demand_mode():
     set_time_response = set_time(latest_block_timestamp + 10000)
 
     latest_block = get_block(block_number="latest", parse=True)
-    assert latest_block["timestamp"] >= latest_block_timestamp + 10000
+    assert latest_block["timestamp"] == latest_block_timestamp + 10000
     assert latest_block["block_hash"] == set_time_response.json()["block_hash"]
     assert_tx_status(deploy_info["tx_hash"], "ACCEPTED_ON_L2")

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -31,6 +31,8 @@ from .util import (
     deploy,
     devnet_in_background,
     get_block,
+    increase_time,
+    set_time,
 )
 
 
@@ -362,3 +364,35 @@ def test_endpoint_if_some_pending():
     deploy(CONTRACT_PATH, inputs=["10"])
     resp = demand_block_creation()
     _assert_correct_block_creation_response(resp)
+
+
+@devnet_in_background("--blocks-on-demand")
+def test_increase_time_in_block_on_demand_mode():
+    """Test block creation with increase_time and pending txs"""
+    deploy_info = deploy(CONTRACT_PATH, inputs=["0"])
+    assert_tx_status(deploy_info["tx_hash"], "PENDING")
+    latest_block_timestamp = get_block(block_number="latest", parse=True)["timestamp"]
+
+    # increase_time which generates a new block with pending txs
+    increase_time_response = increase_time(10000)
+
+    latest_block = get_block(block_number="latest", parse=True)
+    assert latest_block["timestamp"] >= latest_block_timestamp + 10000
+    assert latest_block["block_hash"] == increase_time_response.json()["block_hash"]
+    assert_tx_status(deploy_info["tx_hash"], "ACCEPTED_ON_L2")
+
+
+@devnet_in_background("--blocks-on-demand")
+def test_set_time_in_block_on_demand_mode():
+    """Test block creation with increase_time and pending txs"""
+    deploy_info = deploy(CONTRACT_PATH, inputs=["0"])
+    assert_tx_status(deploy_info["tx_hash"], "PENDING")
+    latest_block_timestamp = get_block(block_number="latest", parse=True)["timestamp"]
+
+    # set_time which generates a new block with pending txs
+    set_time_response = set_time(latest_block_timestamp + 10000)
+
+    latest_block = get_block(block_number="latest", parse=True)
+    assert latest_block["timestamp"] >= latest_block_timestamp + 10000
+    assert latest_block["block_hash"] == set_time_response.json()["block_hash"]
+    assert_tx_status(deploy_info["tx_hash"], "ACCEPTED_ON_L2")

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -373,9 +373,15 @@ def test_increase_time_in_block_on_demand_mode():
     assert_tx_status(deploy_info["tx_hash"], "PENDING")
     latest_block_timestamp = get_block(block_number="latest", parse=True)["timestamp"]
 
-    # increase_time which generates a new block with pending txs
+    # increase time should fail when there are pending transactions
     increase_time_response = increase_time(10000)
+    assert increase_time_response.status_code == 400
 
+    # increase time should succeed with no pending transactions
+    resp = demand_block_creation()
+    assert resp.status_code == 200
+    increase_time_response = increase_time(10000)
+    assert increase_time_response.status_code == 200
     latest_block = get_block(block_number="latest", parse=True)
     assert latest_block["timestamp"] >= latest_block_timestamp + 10000
     assert latest_block["block_hash"] == increase_time_response.json()["block_hash"]
@@ -389,9 +395,15 @@ def test_set_time_in_block_on_demand_mode():
     assert_tx_status(deploy_info["tx_hash"], "PENDING")
     latest_block_timestamp = get_block(block_number="latest", parse=True)["timestamp"]
 
-    # set_time which generates a new block with pending txs
+    # set time should fail when there are pending transactions
     set_time_response = set_time(latest_block_timestamp + 10000)
+    assert set_time_response.status_code == 400
 
+    # set time should succeed with no pending transactions
+    resp = demand_block_creation()
+    assert resp.status_code == 200
+    set_time_response = set_time(latest_block_timestamp + 10000)
+    assert set_time_response.status_code == 200
     latest_block = get_block(block_number="latest", parse=True)
     assert latest_block["timestamp"] == latest_block_timestamp + 10000
     assert latest_block["block_hash"] == set_time_response.json()["block_hash"]

--- a/test/test_blocks_on_demand.py
+++ b/test/test_blocks_on_demand.py
@@ -384,7 +384,7 @@ def test_increase_time_in_block_on_demand_mode():
 
 @devnet_in_background("--blocks-on-demand")
 def test_set_time_in_block_on_demand_mode():
-    """Test block creation with increase_time and pending txs"""
+    """Test block creation with set_time and pending txs"""
     deploy_info = deploy(CONTRACT_PATH, inputs=["0"])
     assert_tx_status(deploy_info["tx_hash"], "PENDING")
     latest_block_timestamp = get_block(block_number="latest", parse=True)["timestamp"]

--- a/test/test_timestamps.py
+++ b/test/test_timestamps.py
@@ -231,8 +231,9 @@ def test_block_info_generator():
 @devnet_in_background("--lite-mode")
 def test_lite_mode_compatibility():
     """Tests compatibility with lite mode"""
-
+    start = int(time.time())
     deploy_info = deploy_ts_contract()
+    BlockInfo.create_for_testing(block_number=0, block_timestamp=start)
 
     set_time(100)
 

--- a/test/test_timestamps.py
+++ b/test/test_timestamps.py
@@ -59,7 +59,7 @@ def set_time(time_s):
     set_time_response = requests.post(f"{APP_URL}/set_time", json={"time": time_s})
 
     if set_time_response == 200:
-        assert set_time_response.json().get("next_block_timestamp") == time_s
+        assert set_time_response.json().get("block_timestamp") == time_s
 
     return set_time_response
 
@@ -101,6 +101,8 @@ def test_increase_time():
 
     # increase time by 1 day
     increase_time(86400)
+    ts_after_increase_time = get_ts_from_last_block()
+    assert ts_after_increase_time >= ts_after_deploy + 86400
 
     # deploy another contract to generate a new block
     deploy_ts_contract()
@@ -128,14 +130,14 @@ def test_set_time():
 
     ts_after_set = get_ts_from_last_block()
 
-    assert ts_after_set == first_block_ts
+    assert ts_after_set == first_block_ts + 86400
 
     # generate a new block by deploying a new contract
     deploy_ts_contract()
 
     second_block_ts = get_ts_from_last_block()
 
-    assert second_block_ts == first_block_ts + 86400
+    assert second_block_ts >= first_block_ts + 86400
 
     # generate a new block by deploying a new contract
     deploy_ts_contract()

--- a/test/test_timestamps.py
+++ b/test/test_timestamps.py
@@ -231,9 +231,7 @@ def test_block_info_generator():
 @devnet_in_background("--lite-mode")
 def test_lite_mode_compatibility():
     """Tests compatibility with lite mode"""
-    start = int(time.time())
     deploy_info = deploy_ts_contract()
-    BlockInfo.create_for_testing(block_number=0, block_timestamp=start)
 
     set_time(100)
 
@@ -241,4 +239,4 @@ def test_lite_mode_compatibility():
     deploy_ts_contract()
 
     time_from_contract = get_ts_from_contract(address=deploy_info["address"])
-    assert time_from_contract == 100
+    assert time_from_contract >= 100

--- a/test/test_timestamps.py
+++ b/test/test_timestamps.py
@@ -2,7 +2,6 @@
 Test block timestamps
 """
 
-import math
 import time
 
 import pytest
@@ -46,19 +45,15 @@ def test_timestamps():
     """Test timestamp"""
     deploy_info = deploy_ts_contract()
     ts_after_deploy = get_ts_from_last_block()
-
     ts_from_first_call = get_ts_from_contract(deploy_info["address"])
-
     assert ts_after_deploy == ts_from_first_call
 
     # deploy another contract to generate a new block
     deploy_ts_contract()
     ts_after_second_deploy = get_ts_from_last_block()
-
     assert ts_after_second_deploy > ts_from_first_call
 
     ts_from_second_call = get_ts_from_contract(deploy_info["address"])
-
     assert ts_after_second_deploy == ts_from_second_call
     assert ts_from_second_call > ts_from_first_call
 
@@ -67,27 +62,15 @@ def test_timestamps():
 @devnet_in_background()
 def test_increase_time():
     """Test timestamp increase time"""
-    start = time.time()
     deploy_info = deploy_ts_contract()
     ts_after_deploy = get_ts_from_last_block()
-
     first_block_ts = get_ts_from_contract(deploy_info["address"])
-
     assert ts_after_deploy == first_block_ts
 
     # increase time by 1 day
     increase_time(86400)
     ts_after_increase_time = get_ts_from_last_block()
     assert ts_after_increase_time >= ts_after_deploy + 86400
-
-    # deploy another contract to generate a new block
-    deploy_ts_contract()
-
-    second_block_ts = get_ts_from_last_block()
-
-    assert second_block_ts - first_block_ts >= 86400
-    elapsed_time = math.ceil(time.time() - start)
-    assert second_block_ts < first_block_ts + 86400 + elapsed_time
 
 
 @pytest.mark.timestamps
@@ -96,28 +79,15 @@ def test_set_time():
     """Test timestamp set time"""
     deploy_info = deploy_ts_contract()
     first_block_ts = get_ts_from_last_block()
-
     ts_from_first_call = get_ts_from_contract(deploy_info["address"])
-
     assert first_block_ts == ts_from_first_call
 
     # set time to 1 day after the deploy
     set_time(first_block_ts + 86400)
-
     ts_after_set = get_ts_from_last_block()
-
     assert ts_after_set == first_block_ts + 86400
-
-    # generate a new block by deploying a new contract
-    deploy_ts_contract()
-
     second_block_ts = get_ts_from_last_block()
-
     assert second_block_ts >= first_block_ts + 86400
-
-    # generate a new block by deploying a new contract
-    deploy_ts_contract()
-
     third_block_ts = get_ts_from_last_block()
 
     # check if offset is still the same
@@ -129,7 +99,6 @@ def test_set_time():
 def test_set_time_argument():
     """Test timestamp set time argument"""
     first_block_ts = get_ts_from_last_block()
-
     assert first_block_ts == SET_TIME_ARGUMENT
 
 
@@ -191,39 +160,29 @@ def test_block_info_generator():
 
     # Test if start time is set by the constructor
     generator = BlockInfoGenerator(start_time=10)
-
     block_with_start_time = generator.next_block(
         block_info=block_info, general_config=DEFAULT_GENERAL_CONFIG
     )
-
     assert block_with_start_time.block_timestamp == 10
 
     # Check if set time can be incrased
-
     generator.increase_time(22)
-
     block_after_increase = generator.next_block(
         block_info=block_info, general_config=DEFAULT_GENERAL_CONFIG
     )
-
     assert block_after_increase.block_timestamp == 32
 
     # Test if start time can be set after increase
-
     generator = BlockInfoGenerator()
     generator.increase_time(1_000_000_000)
-
     block_with_increase_time = generator.next_block(
         block_info=block_info, general_config=DEFAULT_GENERAL_CONFIG
     )
-
     assert block_with_increase_time.block_timestamp >= 1_000_000_000 + int(time.time())
-
     generator.set_next_block_time(222)
     block_after_set_time = generator.next_block(
         block_info=block_info, general_config=DEFAULT_GENERAL_CONFIG
     )
-
     assert block_after_set_time.block_timestamp == 222
 
 
@@ -233,10 +192,8 @@ def test_lite_mode_compatibility():
     """Tests compatibility with lite mode"""
     deploy_info = deploy_ts_contract()
 
+    deploy_ts_contract()
     set_time(100)
 
-    # deploy another contract to generate a new block
-    deploy_ts_contract()
-
     time_from_contract = get_ts_from_contract(address=deploy_info["address"])
-    assert time_from_contract >= 100
+    assert time_from_contract == 100

--- a/test/test_timestamps.py
+++ b/test/test_timestamps.py
@@ -6,14 +6,12 @@ import math
 import time
 
 import pytest
-import requests
 
 from starknet_devnet.block_info_generator import BlockInfo, BlockInfoGenerator
 from starknet_devnet.general_config import DEFAULT_GENERAL_CONFIG
 
-from .settings import APP_URL
 from .shared import ARTIFACTS_PATH
-from .util import call, deploy, devnet_in_background, get_block
+from .util import call, deploy, devnet_in_background, get_block, increase_time, set_time
 
 TS_CONTRACT_PATH = f"{ARTIFACTS_PATH}/timestamp.cairo/timestamp.json"
 TS_ABI_PATH = f"{ARTIFACTS_PATH}/timestamp.cairo/timestamp_abi.json"
@@ -40,28 +38,6 @@ def get_ts_from_contract(address):
 def get_ts_from_last_block():
     """Returns the timestamp of the last block"""
     return get_block(parse=True)["timestamp"]
-
-
-def increase_time(time_s):
-    """Increases the block timestamp offset"""
-    increase_time_response = requests.post(
-        f"{APP_URL}/increase_time", json={"time": time_s}
-    )
-
-    if increase_time_response.status_code == 200:
-        assert increase_time_response.json().get("timestamp_increased_by") == time_s
-
-    return increase_time_response
-
-
-def set_time(time_s):
-    """Sets the block timestamp and offset"""
-    set_time_response = requests.post(f"{APP_URL}/set_time", json={"time": time_s})
-
-    if set_time_response == 200:
-        assert set_time_response.json().get("block_timestamp") == time_s
-
-    return set_time_response
 
 
 @pytest.mark.timestamps

--- a/test/util.py
+++ b/test/util.py
@@ -734,3 +734,25 @@ class ErrorExpector:
 def demand_block_creation():
     """Demand block creation. Useful when devnet started with --blocks-on-demand"""
     return requests.post(f"{APP_URL}/create_block")
+
+
+def increase_time(time_s):
+    """Increases the block timestamp offset"""
+    increase_time_response = requests.post(
+        f"{APP_URL}/increase_time", json={"time": time_s}
+    )
+
+    if increase_time_response.status_code == 200:
+        assert increase_time_response.json().get("timestamp_increased_by") == time_s
+
+    return increase_time_response
+
+
+def set_time(time_s):
+    """Sets the block timestamp and offset"""
+    set_time_response = requests.post(f"{APP_URL}/set_time", json={"time": time_s})
+
+    if set_time_response == 200:
+        assert set_time_response.json().get("block_timestamp") == time_s
+
+    return set_time_response


### PR DESCRIPTION
## Usage related changes

- from now on POST functions `/increase_time` and `/set_time` will change the timestamp and generate a block, in `--blocks-on-demand` mode pending transactions will be included

## Development related changes

- `update_pending_state` function in `StarknetWrapper` class is now public
- 2 new timestamp tests were introduced and some of them were refactored

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `./scripts/test.sh`
