### PR TITLE
Fix get block and get traces in fork mode

### DIFF
--- a/starknet_devnet/origin.py
+++ b/starknet_devnet/origin.py
@@ -184,6 +184,7 @@ class ForkedOrigin(Origin):
             block = await self.__feeder_gateway_client.get_block(block_hash=block_hash)
             if block.block_number > self.get_number_of_blocks():
                 raise custom_exception
+            return block
         except BadRequest as bad_request:
             if is_originally_starknet_exception(bad_request):
                 raise custom_exception from bad_request

--- a/starknet_devnet/origin.py
+++ b/starknet_devnet/origin.py
@@ -180,12 +180,14 @@ class ForkedOrigin(Origin):
             code=StarknetErrorCode.BLOCK_NOT_FOUND,
             message=f"Block hash {block_hash} does not exist.",
         )
-        block = await self.__feeder_gateway_client.get_block(block_hash=block_hash)
-
-        if block.block_number > self.get_number_of_blocks():
-            raise custom_exception
-
-        return block
+        try:
+            block = await self.__feeder_gateway_client.get_block(block_hash=block_hash)
+            if block.block_number > self.get_number_of_blocks():
+                raise custom_exception
+        except BadRequest as bad_request:
+            if is_originally_starknet_exception(bad_request):
+                raise custom_exception from bad_request
+            raise
 
     async def get_block_by_number(self, block_number: int):
         return await self.__feeder_gateway_client.get_block(block_number=block_number)

--- a/starknet_devnet/origin.py
+++ b/starknet_devnet/origin.py
@@ -175,18 +175,17 @@ class ForkedOrigin(Origin):
                 ) from bad_request
             raise
 
-    async def get_block_by_hash(self, block_hash: str):
+    async def get_block_by_hash(self, block_hash: str) -> StarknetBlock:
         custom_exception = StarknetDevnetException(
             code=StarknetErrorCode.BLOCK_NOT_FOUND,
             message=f"Block hash {block_hash} does not exist.",
         )
-        try:
-            block = await self.__feeder_gateway_client.get_block(block_hash=block_hash)
-            if block.block_number > self.get_number_of_blocks():
-                raise custom_exception
-        except BadRequest as bad_request:
-            if is_originally_starknet_exception(bad_request):
-                raise custom_exception from bad_request
+        block = await self.__feeder_gateway_client.get_block(block_hash=block_hash)
+
+        if block.block_number > self.get_number_of_blocks():
+            raise custom_exception
+
+        return block
 
     async def get_block_by_number(self, block_number: int):
         return await self.__feeder_gateway_client.get_block(block_number=block_number)


### PR DESCRIPTION
## Usage related changes

- Fix for `get_block_by_hash` function for old blocks in fork mode 

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `./scripts/test.sh`
