### PR TITLE
Support custom compiler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,6 @@ jobs:
       - run:
           name: Compile test contracts
           command: ./scripts/compile_contracts.sh
-          environment:
-            CAIRO_1_COMPILER_MANIFEST: cairo-compiler/Cargo.toml
       - run:
           name: Check devnet versions
           command: ./scripts/check_versions.sh

--- a/page/docs/guide/run.md
+++ b/page/docs/guide/run.md
@@ -54,6 +54,8 @@ optional arguments:
                         Disable requests schema validation for RPC endpoints
   --disable-rpc-response-validation
                         Disable RPC schema validation for devnet responses
+  --cairo-compiler-manifest CAIRO_COMPILER_MANIFEST
+                        Specify the path to the manifest (Cargo.toml) of the Cairo 1.0 compiler to be used for contract recompilation; if omitted, the default x86-compatible compiler (from cairo-lang package) is used
 ```
 
 You can run `starknet-devnet` in a separate shell, or you can run it in background with `starknet-devnet &`.
@@ -132,6 +134,7 @@ If you don't specify the `HOST` part, the server will indeed be available on all
 ## Run with the Rust implementation of Cairo VM
 
 <!-- # TMP: rust vm -->
+
 ### ⚠️ This feature is temporarily suspended! ⚠️
 
 By default, Devnet uses the [Python implementation](https://github.com/starkware-libs/cairo-lang/) of Cairo VM.

--- a/scripts/install_dev_tools.sh
+++ b/scripts/install_dev_tools.sh
@@ -28,8 +28,11 @@ if [ -z "$CAIRO_1_COMPILER_MANIFEST" ]; then
         --branch v1.0.0-alpha.6 \
         --single-branch
     CAIRO_1_COMPILER_MANIFEST="cairo-compiler/Cargo.toml"
+
     if [ -n "$CIRCLE_BRANCH" ]; then
-        echo "source ~/.cargo/env" >"$BASH_ENV"
+        # needed by further testing steps
+        echo "export CAIRO_1_COMPILER_MANIFEST=$CAIRO_1_COMPILER_MANIFEST" >>"$BASH_ENV"
+        echo "source ~/.cargo/env" >>"$BASH_ENV"
     fi
 fi
 

--- a/scripts/package_build_and_publish.sh
+++ b/scripts/package_build_and_publish.sh
@@ -11,6 +11,7 @@ echo "Local version: $LOCAL_VERSION"
 
 # locate the local version inside the keys array; "null" if not present
 LOCAL_VERSION_INDEX=$(echo "$PYPI_VERSIONS" | jq "index( \"$LOCAL_VERSION\" )")
+echo "Index of local version in PyPI versions: $LOCAL_VERSION_INDEX"
 
 # Building is executed regardles of versions
 poetry build

--- a/starknet_devnet/blueprints/gateway.py
+++ b/starknet_devnet/blueprints/gateway.py
@@ -19,7 +19,7 @@ gateway = Blueprint("gateway", __name__, url_prefix="/gateway")
 async def add_transaction():
     """Endpoint for accepting (state-changing) transactions."""
 
-    transaction = validate_transaction(request.data)
+    transaction = validate_transaction(request.get_data())
     tx_type = transaction.tx_type
 
     response_dict = {

--- a/starknet_devnet/compiler.py
+++ b/starknet_devnet/compiler.py
@@ -1,0 +1,79 @@
+"""Compilation utilities"""
+
+import json
+import os
+import subprocess
+import tempfile
+from abc import ABC
+
+from starkware.starknet.definitions.error_codes import StarknetErrorCode
+from starkware.starknet.services.api.contract_class.contract_class import (
+    CompiledClass,
+    ContractClass,
+)
+from starkware.starknet.services.api.contract_class.contract_class_utils import (
+    compile_contract_class,
+)
+
+from starknet_devnet.util import StarknetDevnetException
+
+
+class ContractClassCompiler(ABC):
+    """Base class of contract class compilers"""
+
+    def compile_contract_class(self, contract_class: ContractClass) -> CompiledClass:
+        """Take the sierra and return the compiled instance"""
+        raise NotImplementedError
+
+
+class DefaultContractClassCompiler(ContractClassCompiler):
+    """Uses the default internal cairo-lang compiler"""
+
+    def compile_contract_class(self, contract_class: ContractClass) -> CompiledClass:
+        return compile_contract_class(contract_class)
+
+
+class CustomContractClassCompiler(ContractClassCompiler):
+    """Uses the compiler whose compiler_manifest is provided in initialization"""
+
+    def __init__(self, compiler_manifest: str):
+        self.compiler_manifest = compiler_manifest
+
+    def compile_contract_class(self, contract_class: ContractClass) -> CompiledClass:
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            contract_json = os.path.join(tmp_dir, "contract.json")
+            contract_casm = os.path.join(tmp_dir, "contract.casm")
+
+            with open(contract_json, mode="w", encoding="utf-8") as tmp_file:
+                contract_class_dumped = contract_class.dump()
+                contract_class_dumped["abi"] = json.loads(contract_class_dumped["abi"])
+                json.dump(contract_class_dumped, tmp_file)
+
+            compilation_args = [
+                "cargo",
+                "run",
+                "--bin",
+                "starknet-sierra-compile",
+                "--manifest-path",
+                self.compiler_manifest,
+                "--",
+                "--allowed-libfuncs-list-name",
+                "experimental_v0.1.0",
+                "--add-pythonic-hints",
+                contract_json,
+                contract_casm,
+            ]
+            compilation = subprocess.run(
+                compilation_args, capture_output=True, check=False
+            )
+            if compilation.returncode:
+                stderr = compilation.stderr.decode("utf-8")
+                raise StarknetDevnetException(
+                    code=StarknetErrorCode.UNEXPECTED_FAILURE,
+                    message=f"Failed compilation to casm! {stderr}",
+                )
+
+            with open(contract_casm, encoding="utf-8") as casm_file:
+                compiled_class = CompiledClass.loads(casm_file.read())
+            return compiled_class

--- a/starknet_devnet/compiler.py
+++ b/starknet_devnet/compiler.py
@@ -34,7 +34,7 @@ class DefaultContractClassCompiler(ContractClassCompiler):
 
 
 class CustomContractClassCompiler(ContractClassCompiler):
-    """Uses the compiler whose compiler_manifest is provided in initialization"""
+    """Uses the compiler according to the compiler_manifest provided in initialization"""
 
     def __init__(self, compiler_manifest: str):
         self.compiler_manifest = compiler_manifest

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -37,9 +37,6 @@ from starkware.starknet.services.api.contract_class.contract_class import (
     DeprecatedCompiledClass,
     EntryPointType,
 )
-from starkware.starknet.services.api.contract_class.contract_class_utils import (
-    compile_contract_class,
-)
 from starkware.starknet.services.api.feeder_gateway.request_objects import (
     CallFunction,
     CallL1Handler,
@@ -79,6 +76,7 @@ from .block_info_generator import BlockInfoGenerator
 from .blocks import DevnetBlocks
 from .blueprints.rpc.structures.types import BlockId, Felt
 from .chargeable_account import ChargeableAccount
+from .compiler import CustomContractClassCompiler, DefaultContractClassCompiler
 from .constants import (
     DUMMY_STATE_ROOT,
     LEGACY_TX_VERSION,
@@ -149,6 +147,12 @@ class StarknetWrapper:
         self.__latest_state = None
         self._contract_classes: Dict[int, Union[DeprecatedCompiledClass, ContractClass]]
         """If v2 - store sierra, otherwise store old class; needed for get_class_by_hash"""
+
+        self._compiler = (
+            CustomContractClassCompiler(config.cairo_compiler_manifest)
+            if config.cairo_compiler_manifest
+            else DefaultContractClassCompiler()
+        )
 
         if config.start_time is not None:
             self.set_block_time(config.start_time)
@@ -281,9 +285,7 @@ class StarknetWrapper:
         visited_storage_entries: Set[StorageEntry] = None,
         nonces: Dict[int, int] = None,
     ):
-        """
-        Update pending state.
-        """
+        """Update pending state."""
         # defaulting
         deployed_contracts = deployed_contracts or []
         explicitly_declared_old = explicitly_declared_old or []
@@ -337,9 +339,7 @@ class StarknetWrapper:
         transaction: DevnetTransaction,
         error_message: str = None,
     ) -> StarknetBlock:
-        """
-        Stores the provided transaction in the transaction storage.
-        """
+        """Stores the provided transaction in the transaction storage."""
         if transaction.status == TransactionStatus.REJECTED:
             assert error_message, "error_message must be present if tx rejected"
             transaction.set_failure_reason(error_message)
@@ -369,7 +369,9 @@ class StarknetWrapper:
             if isinstance(external_tx, Declare):
                 await assert_not_declared(class_hash, compiled_class_hash)
                 compiled_class_hash = tx_handler.internal_tx.compiled_class_hash
-                compiled_class = compile_contract_class(external_tx.contract_class)
+                compiled_class = self._compiler.compile_contract_class(
+                    external_tx.contract_class
+                )
                 compiled_class_hash_computed = compute_compiled_class_hash(
                     compiled_class
                 )
@@ -775,9 +777,7 @@ class StarknetWrapper:
     async def consume_message_from_l2(
         self, from_address: int, to_address: int, payload: List[int]
     ) -> str:
-        """
-        Mocks the L1 contract function consumeMessageFromL2.
-        """
+        """Mocks the L1 contract function consumeMessageFromL2."""
         state = self.get_state()
 
         starknet_message = StarknetMessageToL1(
@@ -987,9 +987,7 @@ class StarknetWrapper:
             await ChargeableAccount(self).deploy()
 
     async def is_deployed(self, address: int) -> bool:
-        """
-        Check if the contract is deployed.
-        """
+        """Check if the contract is deployed."""
         assert isinstance(address, int)
         cached_state = self.get_state().state
         class_hash = await cached_state.get_class_hash_at(address)

--- a/starknet_devnet/starknet_wrapper.py
+++ b/starknet_devnet/starknet_wrapper.py
@@ -760,8 +760,7 @@ class StarknetWrapper:
         block_id: BlockId = DEFAULT_BLOCK_ID,
     ) -> Felt:
         """
-        Returns the storage identified by `key`
-        from the contract at `contract_address`.
+        Returns the storage identified by `key` from the contract at `contract_address`.
         """
         state = await self.__get_query_state(block_id)
         return hex(await state.state.get_storage_at(contract_address, key))

--- a/test/test_compiler.py
+++ b/test/test_compiler.py
@@ -1,0 +1,110 @@
+"""Test cairo recompilers"""
+
+import os
+import subprocess
+
+import pytest
+from starkware.starknet.services.api.contract_class.contract_class import CompiledClass
+from starkware.starknet.services.api.contract_class.contract_class_utils import (
+    load_sierra,
+)
+
+from starknet_devnet.compiler import (
+    ContractClassCompiler,
+    CustomContractClassCompiler,
+    DefaultContractClassCompiler,
+)
+
+from .account import send_declare_v2
+from .shared import (
+    CONTRACT_1_CASM_PATH,
+    CONTRACT_1_PATH,
+    PREDEPLOY_ACCOUNT_CLI_ARGS,
+    PREDEPLOYED_ACCOUNT_ADDRESS,
+    PREDEPLOYED_ACCOUNT_PRIVATE_KEY,
+)
+from .test_declare_v2 import assert_declare_v2_accepted, load_cairo1_contract
+from .util import (
+    DevnetBackgroundProc,
+    devnet_in_background,
+    read_stream,
+    terminate_and_wait,
+)
+
+SPECIFIED_MANIFEST = os.getenv("CAIRO_1_COMPILER_MANIFEST")
+
+ACTIVE_DEVNET = DevnetBackgroundProc()
+
+
+@pytest.fixture(autouse=True)
+def run_before_and_after_test():
+    """Cleanup after tests finish."""
+
+    # before test
+    ACTIVE_DEVNET.stop()
+    yield
+    # after test
+    ACTIVE_DEVNET.stop()
+
+
+@pytest.mark.parametrize(
+    "compiler",
+    [DefaultContractClassCompiler(), CustomContractClassCompiler(SPECIFIED_MANIFEST)],
+)
+def test_contract_class_compiler_happy_path(compiler: ContractClassCompiler):
+    """Test the class abstracting the default compiler"""
+    contract_class = load_sierra(CONTRACT_1_PATH)
+    compiled = compiler.compile_contract_class(contract_class)
+
+    with open(CONTRACT_1_CASM_PATH, encoding="utf-8") as casm_file:
+        expected_compiled = CompiledClass.loads(casm_file.read())
+
+    assert compiled == expected_compiled
+
+
+@pytest.mark.parametrize("compiler_manifest", ["", "dummy-wrong"])
+def test_invalid_cairo_compiler_manifest(compiler_manifest: str):
+    """Test invalid cairo compiler manifest specified via CLI"""
+
+    execution = ACTIVE_DEVNET.start(
+        "--cairo-compiler-manifest",
+        compiler_manifest,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+    )
+
+    assert execution.returncode != 0
+    assert "Cairo compiler error" in read_stream(execution.stderr)
+    assert read_stream(execution.stdout) == ""
+
+
+def test_valid_cairo_compiler_manifest():
+    """Test valid cairo compiler manifest specified via CLI"""
+
+    assert SPECIFIED_MANIFEST
+
+    execution = ACTIVE_DEVNET.start(
+        "--cairo-compiler-manifest",
+        SPECIFIED_MANIFEST,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+    )
+    terminate_and_wait(execution)
+    assert execution.returncode == 0
+    assert "Cairo compiler error" not in read_stream(execution.stderr)
+    assert "Using cairo compiler" in read_stream(execution.stdout)
+
+
+@devnet_in_background(
+    *PREDEPLOY_ACCOUNT_CLI_ARGS, "--cairo-compiler-manifest", SPECIFIED_MANIFEST
+)
+def test_declaring_with_custom_compiler():
+    """E2E test using cairo compiler specified via CLI"""
+    contract_class, _, compiled_class_hash = load_cairo1_contract()
+    resp = send_declare_v2(
+        contract_class=contract_class,
+        compiled_class_hash=compiled_class_hash,
+        sender_address=PREDEPLOYED_ACCOUNT_ADDRESS,
+        sender_key=PREDEPLOYED_ACCOUNT_PRIVATE_KEY,
+    )
+    assert_declare_v2_accepted(resp)

--- a/test/test_compiler.py
+++ b/test/test_compiler.py
@@ -81,7 +81,7 @@ def test_invalid_cairo_compiler_manifest(compiler_manifest: str):
 def test_valid_cairo_compiler_manifest():
     """Test valid cairo compiler manifest specified via CLI"""
 
-    assert SPECIFIED_MANIFEST
+    assert SPECIFIED_MANIFEST, "Compiler manifest not set through env var"
 
     execution = ACTIVE_DEVNET.start(
         "--cairo-compiler-manifest",


### PR DESCRIPTION
## Usage related changes

- Close #422
- Introduce `--cairo-compiler-manifest <PATH>` CLI option which will allow:
   - Recompilation of cairo 1.0 classes on non-x86 platforms (basically all platforms where users can install the cairo compiler will be supported)
   - Compiling using whichever compiler version the user finds appropriate
- docs ok? (TODO)

## Development related changes

- Introduce compiler wrapper classes in `compiler.py`: `ContractClassCompiler` (abstract), `DefaultContractClassCompiler`, `CustomContractClassCompiler`
- I did slight manipulation of docstring in starknet_wrapper.py in order to reduce the number of lines (linter complains if line count > 1000, which I didn't want to suppress)
  - This motivated me to open https://github.com/Shard-Labs/starknet-devnet/issues/427

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/lint.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `./scripts/test.sh`
