### PR TITLE
check for cairo1 installation with starknet-sierra-compile

### DIFF
--- a/starknet_devnet/devnet_config.py
+++ b/starknet_devnet/devnet_config.py
@@ -218,7 +218,7 @@ def _parse_cairo_compiler_manifest(manifest_path: str):
             "cargo",
             "run",
             "--bin",
-            "starknet-compile",
+            "starknet-sierra-compile",
             "--manifest-path",
             manifest_path,
             "--",


### PR DESCRIPTION
starknet-compile is no longer built at cairo tip of tree,

before it was built as part of the cairo-lang-starknet crate: https://github.com/starkware-libs/cairo/blob/8a86166b8f219c7fea116bc0e5ec89f2a0f8e87f/crates/cairo-lang-starknet/Cargo.toml#L53

but no longer exists now:
https://github.com/starkware-libs/cairo/blob/23903636c498ce62748078e749382294cfa7f38e/crates/cairo-lang-starknet/Cargo.toml#L53

.. which causes using a provided cairo installation with `--cairo-compiler-manifest` to fail the check. check with starknet-sierra-compile instead, which is also the actual binary used in compiler.py.